### PR TITLE
ci: add turbo to run dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "portal",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "@next/font": "13.1.5",
-    "@types/node": "18.11.18",
-    "@types/react": "18.0.27",
-    "@types/react-dom": "18.0.10",
-    "eslint": "8.32.0",
-    "eslint-config-next": "13.1.5",
-    "next": "13.1.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "4.9.4"
-  }
+    "name": "portal",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev --turbo",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "dependencies": {
+        "@next/font": "13.1.5",
+        "@types/node": "18.11.18",
+        "@types/react": "18.0.27",
+        "@types/react-dom": "18.0.10",
+        "eslint": "8.32.0",
+        "eslint-config-next": "13.1.5",
+        "next": "13.1.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "typescript": "4.9.4"
+    }
 }


### PR DESCRIPTION
👉 This PR enables `turbo` in place of `webpack` to build the app in development mode, according to the [docs](https://beta.nextjs.org/docs/configuring/turbopack).

ℹ️ For now, it's an `alpha` version so `turbo` is still not configurable or not ready for production usage.