### PR TITLE
docs/describe-pnpm-vitejs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,19 @@ jobs:
   build-pnpm:
     runs-on: ubuntu-22.04
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 7.27.0
 
-      - name: Check out repository
-        uses: actions/checkout@v3
-
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
           node-version: 16.19
+          cache: 'pnpm'
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,19 +86,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Setup node environment (for building)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.19
-
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 7.27.0
 
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.19
+          cache: 'pnpm'
+
       - name: Fetch dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
 
       - name: Lint typescript
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,15 +20,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      - name: Setup node environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.19
-
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 7.27.0
+
+      - name: Setup node environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.19
+          cache: 'pnpm'
 
       - name: Fetch dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)
 [![typescript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Next JS](https://img.shields.io/badge/Next%2013-black?style=for-the-badge&logo=next.js&logoColor=white)](https://nextjs.org/)
+[![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)](https://www.google.com/search?client=safari&rls=en&q=vitejs&ie=UTF-8&oe=UTF-8)
 [![prettier](https://img.shields.io/badge/prettier-1A2C34?style=for-the-badge&logo=prettier&logoColor=F7BA3E)](https://github.com/prettier/prettier)
 [![license][bsd-3-clause-image]][bsd-3-clause]
 [![cc-by-sa-4.0][cc-by-sa-image]][cc-by-sa]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)
 [![typescript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)](https://www.google.com/search?client=safari&rls=en&q=vitejs&ie=UTF-8&oe=UTF-8)
+[![vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)](https://www.google.com/search?client=safari&rls=en&q=vitejs&ie=UTF-8&oe=UTF-8)
+[![pnpm](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)](https://pnpm.io)
 [![prettier](https://img.shields.io/badge/prettier-1A2C34?style=for-the-badge&logo=prettier&logoColor=F7BA3E)](https://github.com/prettier/prettier)
 [![license][bsd-3-clause-image]][bsd-3-clause]
 [![cc-by-sa-4.0][cc-by-sa-image]][cc-by-sa]

--- a/README.md
+++ b/README.md
@@ -28,30 +28,37 @@ These instructions will get you a project up and running on your local machine f
 Be sure to have the following properly installed:
 
 - [Node.js](https://nodejs.org/ru/) `v16.19` ([gallium](https://nodejs.org/en/blog/release/v16.19.0/))
-- [yarn](https://yarnpkg.com)
+- [pnpm](https://pnpm.io/) `v7.27`
+- [Docker](https://www.docker.com/)
 
 ### Setup
 
-🚚 Install the dependencies and build the project:
+Install the dependencies and build the project:
 
 ```sh
-yarn
-
-yarn build
+pnpm install
 ```
 
-### Environment variables
+### Launch
 
-The project relies on several environment variables for proper functioning. These variables should be set in a file named `.env.local` at the root of the project.
-Checkout [nextjs documentation](https://nextjs.org/docs/basic-features/environment-variables) for more.
+Run the server with the following command line.
 
-```shell
-# The title of the application that will be displayed in the browser's title bar.
-APP_TITLE=
-# A comma-separated list of keywords relevant to the application (used by search engines).
-APP_KEYWORDS=
-# A brief description of the application (used by search engines).
-APP_DESCRIPTION=
+```sh
+pnpm dev
+```
+
+The portal will be available at <http://127.0.0.1:5173>.
+
+## Docker image
+
+The Docker image can be used to run the application in a container. The Dockerfile is located in the root directory of the project.
+
+### Building the Docker Image
+
+To build the Docker image, use the following command:
+
+```sh
+docker build -t dataverse-portal .
 ```
 
 Note that the `.env.local` file is not tracked by version control and should not be committed to the repository.

--- a/README.md
+++ b/README.md
@@ -61,17 +61,15 @@ To build the Docker image, use the following command:
 docker build -t dataverse-portal .
 ```
 
-Note that the `.env.local` file is not tracked by version control and should not be committed to the repository.
+### Running the Docker Container
 
-### Launch
-
-Run the server with the following command line.
+To run the Docker container, use the following command (adapt the arguments as needed):
 
 ```sh
-yarn start
+docker run --rm -ti -p 8080:80 dataverse-portal
 ```
 
-The portal will be available at <http://localhost:3000>.
+The command will start the Docker container and bind it to port `8080` on your local machine. You can access the application by navigating to <http://localhost:8080> in your web browser.
 
 ## License
 


### PR DESCRIPTION
This PR updates the README to reflect the new stack used in the project, specifically by replacing `NextJS` with `ViteJS` and `yarn` by `pnpm`. The README also provides information on how to build the docker image and run the container. 

In addition, this PR improves the CI by enabling the caching of node modules (as explained [here](https://pnpm.io/continuous-integration#github-actions)).