### PR TITLE
Build/environment variables

### DIFF
--- a/config/html-config.ts
+++ b/config/html-config.ts
@@ -1,0 +1,60 @@
+import { URL } from 'url'
+import type { Options } from 'vite-plugin-html-config'
+import pkg from '../package.json'
+
+const options: Options = {
+  favicon: '/favicon.svg',
+  title: 'OKP4 Dataverse Portal',
+  metas: [
+    {
+      name: 'viewport',
+      content: 'width=device-width, initial-scale=1.0'
+    },
+    {
+      name: 'description',
+      content: pkg.description
+    },
+    {
+      name: 'author',
+      content: pkg.author.name
+    },
+    {
+      name: 'og:type',
+      content: 'website'
+    },
+    {
+      name: 'og:title',
+      content: 'OKP4 Dataverse Portal'
+    },
+    {
+      name: 'og:description',
+      content: pkg.description
+    },
+    {
+      name: 'keywords',
+      content: [
+        'OKP4',
+        'Portal',
+        'Data App',
+        'Dataverse',
+        'Services',
+        'Dataset',
+        'Data Space',
+        'Deposit',
+        'Catalog',
+        'Files',
+        'Blockchain',
+        'Metadata',
+        'Exploration',
+        'Know',
+        'Token'
+      ].join(', ')
+    },
+    {
+      name: 'version',
+      content: pkg.version
+    }
+  ]
+}
+
+export default options

--- a/index.html
+++ b/index.html
@@ -2,9 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "stylelint-scss": "^4.4.0",
     "typescript": "^4.9.3",
     "vite": "^4.1.0",
+    "vite-plugin-html-config": "^1.0.11",
     "vite-plugin-svgr": "^2.4.0",
     "zustand": "^4.3.3"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@okp4/dataverse-portal",
   "version": "0.1.0",
   "private": false,
+  "repository": "git@github.com:okp4/dataverse-portal.git",
+  "license": "BSD-3-Clause",
+  "description": "Dataverse portal for the OKP4 network.",
+  "homepage": "https://github.com/okp4/dataverse-portal",
+  "author": {
+    "name": "OKP4",
+    "web": "https://okp4.network"
+  },
   "engines": {
     "node": "^16.19",
     "pnpm": "^7.27.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ specifiers:
   stylelint-scss: ^4.4.0
   typescript: ^4.9.3
   vite: ^4.1.0
+  vite-plugin-html-config: ^1.0.11
   vite-plugin-svgr: ^2.4.0
   zustand: ^4.3.3
 
@@ -61,6 +62,7 @@ devDependencies:
   stylelint-scss: 4.4.0_stylelint@15.1.0
   typescript: 4.9.5
   vite: 4.1.1_sass@1.58.2
+  vite-plugin-html-config: 1.0.11_vite@4.1.1
   vite-plugin-svgr: 2.4.0_vite@4.1.1
   zustand: 4.3.3_immer@9.0.19+react@18.2.0
 
@@ -4810,6 +4812,15 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /vite-plugin-html-config/1.0.11_vite@4.1.1:
+    resolution: {integrity: sha512-hUybhgI+/LQQ5q6xoMMsTvI4PBuQD/Wv6Z1vtDPVWjanS8weCIexXuLLYNGD/93f0v8W2hpNfXpmxgpZMahJ0g==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      vite: '>=2.0.0'
+    dependencies:
+      vite: 4.1.1_sass@1.58.2
     dev: true
 
   /vite-plugin-svgr/2.4.0_vite@4.1.1:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,14 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src')
     }
-  }
+  },
+  build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'react-vendor': ['react', 'react-dom', 'react-router-dom']
+          }
+        }
+      }
+    },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,17 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import svgr from 'vite-plugin-svgr'
 import path from 'path'
+import htmlConfig from 'vite-plugin-html-config'
+
+import htmlConfigOptions from './config/html-config'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr()],
+  plugins: [
+    htmlConfig(htmlConfigOptions),
+    react(), 
+    svgr()
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')


### PR DESCRIPTION
This PR introduces the parametrization of the HTML `favicon` `title` and `meta tags` (`keywords`, `description`, `version`...) using the ViteJS plugin [vite-plugin-html-config](https://github.com/ahwgs/vite-plugin-html-config). Obvisously, the values are injected in the HTML during build time.