### PR TITLE
fix: fix html title generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title></title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Self explanatory. Fixes #55 - the HTML `title` was not generated during the build process. Currently, it appears that the `title` needs to exist in the HTML source code to be properly generated by [vite-plugin-html-config](https://github.com/ahwgs/vite-plugin-html-config).