### PR TITLE
Feat/fp-ts part ][

### DIFF
--- a/src/util/effect.spec.ts
+++ b/src/util/effect.spec.ts
@@ -9,11 +9,12 @@ import * as E from 'fp-ts/Either'
 
 describe('Considering the toEffectul() function', () => {
   describe.each`
-    desc                                            | fn                                                      | args       | expectedResult
-    ${'an IO function that returns a string'}       | ${(): IO<string> => () => 'foo'}                        | ${[]}      | ${'foo'}
-    ${'an IOEither function that returns a string'} | ${(v: string): IOEither<never, string> => IOE.right(v)} | ${['foo']} | ${E.right('foo')}
+    desc                                             | fn                                                      | args       | expectedResult
+    ${'an IO function that returns a string'}        | ${(): IO<string> => () => 'foo'}                        | ${[]}      | ${'foo'}
+    ${'an IOEither function that returns a string'}  | ${(v: string): IOEither<never, string> => IOE.right(v)} | ${['foo']} | ${E.right('foo')}
     ${'a Task function that returns a number'} | ${(v: number): Task<number> =>
   () => Promise.resolve(v)} | ${[42]} | ${42}
+    ${'an effectful function that returns a number'} | ${(v: number): number => v}                             | ${[42]}    | ${42}
   `(
     'Given the test case <$desc>',
     ({

--- a/src/util/effect.spec.ts
+++ b/src/util/effect.spec.ts
@@ -1,6 +1,6 @@
+/* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/promise-function-async */
-import { toEffectful } from './effect'
-import type { ComputationalFunc } from './effect'
+import { toEffectful, toEffectfulObject } from './effect'
 import type { IO } from 'fp-ts/lib/IO'
 import type { IOEither } from 'fp-ts/lib/IOEither'
 import type { Task } from 'fp-ts/lib/Task'
@@ -9,12 +9,13 @@ import * as E from 'fp-ts/Either'
 
 describe('Considering the toEffectul() function', () => {
   describe.each`
-    desc                                             | fn                                                      | args       | expectedResult
-    ${'an IO function that returns a string'}        | ${(): IO<string> => () => 'foo'}                        | ${[]}      | ${'foo'}
-    ${'an IOEither function that returns a string'}  | ${(v: string): IOEither<never, string> => IOE.right(v)} | ${['foo']} | ${E.right('foo')}
+    desc                                             | fn                                                      | args         | expectedResult
+    ${'an IO function that returns a string'}        | ${(): IO<string> => () => 'foo'}                        | ${[]}        | ${'foo'}
+    ${'an IOEither function that returns a string'}  | ${(v: string): IOEither<never, string> => IOE.right(v)} | ${['foo']}   | ${E.right('foo')}
     ${'a Task function that returns a number'} | ${(v: number): Task<number> =>
   () => Promise.resolve(v)} | ${[42]} | ${42}
-    ${'an effectful function that returns a number'} | ${(v: number): number => v}                             | ${[42]}    | ${42}
+    ${'an effectful function that returns a number'} | ${(v: number): number => v}                             | ${[42]}      | ${42}
+    ${'a value'}                                     | ${'foo'}                                                | ${undefined} | ${'foo'}
   `(
     'Given the test case <$desc>',
     ({
@@ -22,32 +23,71 @@ describe('Considering the toEffectul() function', () => {
       args,
       expectedResult
     }: {
-      fn: ComputationalFunc
-      args: unknown[]
+      fn: (...args: unknown[]) => unknown | unknown
+      args: unknown[] | undefined
       expectedResult: unknown
     }) => {
       describe('When calling function toEffectful()', () => {
         const effectfulFn = toEffectful(fn)
 
-        test(`Then, the result is a function`, () => {
-          expect(typeof effectfulFn).toEqual('function')
-        })
-
-        describe(`And when calling that function`, () => {
-          const result = effectfulFn(...args)
-
-          test(`Then, the result is as expected`, async () => {
-            // check if result is a promise
-            if (result instanceof Promise) {
-              const value = await result
-
-              expect(value).toEqual(expectedResult)
-            } else {
-              expect(result).toEqual(expectedResult)
-            }
+        if (args === undefined) {
+          test(`Then, the result is as expected`, () => {
+            expect(effectfulFn).toEqual(expectedResult)
           })
-        })
+        } else {
+          test(`Then, the result is a function`, () => {
+            expect(typeof effectfulFn).toEqual('function')
+          })
+
+          describe(`And when calling that function`, () => {
+            const result = effectfulFn(...args)
+
+            test(`Then, the result is as expected`, async () => {
+              // check if result is a promise
+              if (result instanceof Promise) {
+                const value = await result
+
+                expect(value).toEqual(expectedResult)
+              } else {
+                expect(result).toEqual(expectedResult)
+              }
+            })
+          })
+        }
       })
     }
   )
+})
+
+describe('Considering the toEffectulObject() function', () => {
+  describe('When calling function toEffectfulObject()', () => {
+    const obj = {
+      a: (): IO<string> => () => 'foo',
+      b:
+        (v: string): IO<string> =>
+        () =>
+          v,
+      c:
+        (v: number): Task<number> =>
+        () =>
+          Promise.resolve(v),
+      d: (v: number): number => v,
+      e: 'foo'
+    }
+
+    const result: {
+      a: () => string
+      b: (v: string) => string
+      c: (v: number) => Promise<number>
+      d: (v: number) => number
+      e: string
+    } = toEffectfulObject(obj)
+    test(`Then, the result is as expected`, () => {
+      expect(result.a()).toEqual('foo')
+      expect(result.b('bar')).toEqual('bar')
+      expect(result.c(42)).resolves.toEqual(42)
+      expect(result.d(42)).toEqual(42)
+      expect(result.e).toEqual('foo')
+    })
+  })
 })

--- a/src/util/effect.ts
+++ b/src/util/effect.ts
@@ -1,18 +1,28 @@
 import type { Task } from 'fp-ts/Task'
 import type { IO } from 'fp-ts/IO'
 
-// Defines the type of function that returns an IO or a Task also known as a computational function.
-export type ComputationalFunc = (...args: unknown[]) => IO<unknown> | Task<unknown>
-
-type EffectfulResultType<F extends ComputationalFunc> = ReturnType<F> extends IO<infer T>
-  ? T
-  : ReturnType<F> extends Task<infer U>
-  ? Promise<U>
-  : never
+// ToEffectful is a utility type that converts a computational function (i.e a function that returns an IO or a Task) to a function that returns
+// its result directly (producing a side effect), else it returns the same type.
+export type ToEffectful<T> = T extends (...args: infer Args) => IO<infer R>
+  ? (...args: Args) => R
+  : T extends (...args: infer Args) => Task<infer R>
+  ? (...args: Args) => Promise<R>
+  : T
 
 // toEffectful is an utility function that converts a computational function (i.e a function that returns an IO or a Task) to a function that returns
-// its result directly (producing a side effect).
-export const toEffectful =
-  <F extends ComputationalFunc>(fn: F): ((...args: Parameters<F>) => EffectfulResultType<F>) =>
-  (...args: Parameters<F>) =>
-    fn(...args)() as EffectfulResultType<F>
+// its result directly (producing a side effect), else it does nothing.
+export const toEffectful = <T>(v: T): ToEffectful<T> => {
+  if (typeof v !== 'function') {
+    return v as ToEffectful<T>
+  }
+
+  return ((...args: unknown[]) => {
+    const result = v(...args)
+
+    if (typeof result === 'function') {
+      return result()
+    }
+
+    return result
+  }) as ToEffectful<T>
+}

--- a/src/util/effect.ts
+++ b/src/util/effect.ts
@@ -11,21 +11,14 @@ export type ToEffectful<T> = T extends (...args: infer Args) => IO<infer R>
 
 // toEffectful is an utility function that converts a computational function (i.e a function that returns an IO or a Task) to a function that returns
 // its result directly (producing a side effect), else it does nothing.
-export const toEffectful = <T>(v: T): ToEffectful<T> => {
-  if (typeof v !== 'function') {
-    return v as ToEffectful<T>
-  }
+export const toEffectful = <T>(v: T): ToEffectful<T> =>
+  typeof v !== 'function'
+    ? (v as ToEffectful<T>)
+    : (((...args: unknown[]) => {
+        const result = v(...args)
 
-  return ((...args: unknown[]) => {
-    const result = v(...args)
-
-    if (typeof result === 'function') {
-      return result()
-    }
-
-    return result
-  }) as ToEffectful<T>
-}
+        return typeof result === 'function' ? result() : result
+      }) as ToEffectful<T>)
 
 // ToEffectfulObject is a utility type that converts a computational object (i.e an object that contains computational functions) to an object that
 // contains functions that return their result directly (producing a side effect), leaving the type of the other properties unmodified.
@@ -40,9 +33,11 @@ export type ToEffectfulObject<T extends Record<string, unknown>> = {
 // toEffectfulObject is an utility function that converts a computational object (i.e an object that contains computational functions) to an object that
 // contains functions that return their result directly (producing a side effect), leaving the rest of the object untouched.
 export function toEffectfulObject<T extends Record<string, unknown>>(obj: T): ToEffectfulObject<T> {
-  return Object.keys(obj).reduce((result: Record<string, unknown>, key: string) => {
-    result[key] = toEffectful(obj[key])
-
-    return result
-  }, {}) as ToEffectfulObject<T>
+  return Object.keys(obj).reduce(
+    (result: Record<string, unknown>, key: string) => ({
+      ...result,
+      [key]: toEffectful(obj[key])
+    }),
+    {}
+  ) as ToEffectfulObject<T>
 }

--- a/src/util/effect.ts
+++ b/src/util/effect.ts
@@ -26,3 +26,23 @@ export const toEffectful = <T>(v: T): ToEffectful<T> => {
     return result
   }) as ToEffectful<T>
 }
+
+// ToEffectfulObject is a utility type that converts a computational object (i.e an object that contains computational functions) to an object that
+// contains functions that return their result directly (producing a side effect), leaving the type of the other properties unmodified.
+export type ToEffectfulObject<T extends Record<string, unknown>> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => IO<infer R>
+    ? (...args: Args) => R
+    : T[K] extends (...args: infer Args) => Task<infer R>
+    ? (...args: Args) => Promise<R>
+    : T[K]
+}
+
+// toEffectfulObject is an utility function that converts a computational object (i.e an object that contains computational functions) to an object that
+// contains functions that return their result directly (producing a side effect), leaving the rest of the object untouched.
+export function toEffectfulObject<T extends Record<string, unknown>>(obj: T): ToEffectfulObject<T> {
+  return Object.keys(obj).reduce((result: Record<string, unknown>, key: string) => {
+    result[key] = toEffectful(obj[key])
+
+    return result
+  }, {}) as ToEffectfulObject<T>
+}


### PR DESCRIPTION
This is a continuation of #75 that generalizes the functions to support objects containing computational functions. It is mainly intended to transform [Zustand](https://github.com/pmndrs/zustand) store using [fp-ts](https://gcanti.github.io/fp-ts/) into regular stores.