### PR TITLE
Feat: make work in progress page centered

### DIFF
--- a/src/page/workInProgress/workInProgress.scss
+++ b/src/page/workInProgress/workInProgress.scss
@@ -1,8 +1,10 @@
 @import '@/style/fonts.scss';
 @import '@/style/theme.scss';
+@import '@/style/mixins.scss';
 
 .okp4-dataverse-portal-work-in-progress-main {
   @include with-theme() {
+    @include grid-item($colStart: 1, $colEnd: 13, $rowStart: 2, $rowEnd: auto);
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
As we decided to keep `Work in prorgess` in `Explore` page, this PR updates its position in the grid layout.

![Capture d’écran 2023-03-10 à 11 12 12](https://user-images.githubusercontent.com/35332974/224289131-8234f3ce-7d15-4104-b192-a26198800d83.png)
