### PR TITLE
fix(sidebar): add condition to render alpha version

### DIFF
--- a/src/component/sidebar/sidebar.tsx
+++ b/src/component/sidebar/sidebar.tsx
@@ -59,13 +59,15 @@ export const Sidebar: FC = () => {
           collapsed: !isSidebarExpanded
         })}
       >
-        <p className="okp4-dataverse-portal-sidebar-footer-version text">Alpha Version</p>
         {isSidebarExpanded && (
-          <Button
-            icons={{ startIcon: <Icon name="feedback" /> }}
-            label={t('sidebar.footer.feedback')}
-            onClick={handleFeedbackClick}
-          />
+          <>
+            <p className="okp4-dataverse-portal-sidebar-footer-version text">Alpha Version</p>
+            <Button
+              icons={{ startIcon: <Icon name="feedback" /> }}
+              label={t('sidebar.footer.feedback')}
+              onClick={handleFeedbackClick}
+            />
+          </>
         )}
         <div
           className={classnames('okp4-dataverse-portal-sidebar-footer-social-medias-container', {


### PR DESCRIPTION
This PR aims to hide the "ALPHA VERSION" mention on collapsed sidebar.
It should be visible only when the sidebar is expanded.

Currently we have:

![Capture d’écran 2023-03-14 à 12 50 31](https://user-images.githubusercontent.com/35332974/224992877-168f0f72-c3f0-4d91-b0ea-d35e6d239dd0.png)

And it should be:

![Capture d’écran 2023-03-14 à 12 50 49](https://user-images.githubusercontent.com/35332974/224992894-b056ce3e-b696-42ec-b249-7b3ffd412d60.png)
