### PR TITLE
Feat/remove uppercase text from button

### DIFF
--- a/src/component/button/button.scss
+++ b/src/component/button/button.scss
@@ -59,11 +59,9 @@
       .okp4-dataverse-portal-button-label {
         @include noto-sans(700);
         font-size: 11px;
-        text-transform: uppercase;
 
         &.tertiary {
           @include noto-sans(400);
-          text-transform: unset;
           font-size: 16px;
         }
       }

--- a/src/component/sidebar/sidebar.scss
+++ b/src/component/sidebar/sidebar.scss
@@ -109,6 +109,10 @@
         }
       }
 
+      .okp4-dataverse-portal-button-label {
+        text-transform: uppercase;
+      }
+
       .okp4-dataverse-portal-sidebar-footer-social-medias-container {
         display: flex;
         align-items: center;


### PR DESCRIPTION
This PR allows you to remove the uppercase text style incorporated directly into the button component. 
This style has been added directly to the button that needs it, to avoid applying it to all buttons.