### PR TITLE
Fix/portal page content and toolbar overlapping

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -69,6 +69,8 @@ p {
 
       &.expanded-sidebar {
         @include blurred-page(1px);
+        position: absolute;
+        left: 299px;
       }
     }
 
@@ -78,6 +80,8 @@ p {
 
       &.expanded-sidebar {
         @include blurred-page(1px);
+        position: absolute;
+        left: 376px;
       }
     }
 


### PR DESCRIPTION
This pr allows to remedy the overflow of the page elements on the sidebar when it is opened on small screens.
The page elements must be pushed, and for the moment the position: absolute is used to overcome the problem.


<details>
<summary>Here is the application before the fix:</summary>

![Capture d’écran 2023-03-23 à 12 17 51](https://user-images.githubusercontent.com/35332974/227188861-ca34508b-99ef-4b38-a18c-89feea143a5f.png)

![Capture d’écran 2023-03-23 à 12 17 54](https://user-images.githubusercontent.com/35332974/227188863-73958e5c-c07c-46aa-a0e5-817517887570.png)

</details>


<details>
<summary>After:</summary>

![Capture d’écran 2023-03-23 à 12 14 50](https://user-images.githubusercontent.com/35332974/227188926-d3c523cb-45ae-490a-ad5d-eafe76846f1c.png)

![Capture d’écran 2023-03-23 à 12 14 40](https://user-images.githubusercontent.com/35332974/227188930-ea0a5fa0-3cfd-4505-b7af-733e5e98bcab.png)

</details>


This PR is waiting for this one in order to merge: https://github.com/okp4/dataverse-portal/pull/118


