### PR TITLE
Style/align dataverse card with mock up

### DIFF
--- a/src/component/button/button.scss
+++ b/src/component/button/button.scss
@@ -104,9 +104,13 @@
       display: flex;
       align-items: center;
 
-      &.primary,
-      &.secondary {
+      &.primary {
         padding: 12px 20px;
+        gap: 12px;
+      }
+
+      &.secondary {
+        padding: 8px 16px;
         gap: 12px;
       }
 

--- a/src/component/card/dataverseCard/dataverseCard.scss
+++ b/src/component/card/dataverseCard/dataverseCard.scss
@@ -34,7 +34,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 27px;
+      gap: 17px;
 
       @include desktop-bp {
         width: 88%;


### PR DESCRIPTION
This is to align the secondary button style to the mock-up. The PR also reduces the gap in the dataverse card content to make sure paddings are respected