### PR TITLE
Fix: update grid space management from auto fit to auto fill

### DIFF
--- a/src/page/dataverse/dataverse.scss
+++ b/src/page/dataverse/dataverse.scss
@@ -170,7 +170,7 @@
       .okp4-dataverse-portal-dataverse-page-cards-container {
         @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: 3);
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
         grid-auto-rows: 220px;
         gap: 43px;
 
@@ -179,17 +179,17 @@
         }
 
         @include mobile-bp {
-          grid-template-columns: repeat(auto-fit, minmax(342px, 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(342px, 1fr));
           gap: 20px;
         }
 
         @include tablet-bp {
-          grid-template-columns: repeat(auto-fit, minmax(342px, 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(342px, 1fr));
           gap: 36px;
         }
 
         @include large-desktop-bp {
-          grid-template-columns: repeat(auto-fit, minmax(330px, 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
           gap: 29px;
         }
       }


### PR DESCRIPTION
This PR fixes the fact that when there is only one card to display in the `dataverse` page, it takes all the available space.




<details>
<summary>Large:</summary>

Before: 

![Capture d’écran 2023-03-24 à 08 39 46](https://user-images.githubusercontent.com/35332974/227457008-faabf22c-fa5b-466d-9450-70aedff5bbaf.png)

After: 

![Capture d’écran 2023-03-24 à 08 37 22](https://user-images.githubusercontent.com/35332974/227457041-96ddcfae-147b-4e75-93f6-6a0f7d0cc63b.png)

</details>


<details>
<summary>Medium:</summary>

Before: 

![Capture d’écran 2023-03-24 à 08 39 22](https://user-images.githubusercontent.com/35332974/227457150-24799da6-ca0e-4ea7-ba4e-a6df418c98af.png)

After: 

![Capture d’écran 2023-03-24 à 08 37 30](https://user-images.githubusercontent.com/35332974/227457169-b759670c-0516-4fbc-960f-e5cb72ab32f0.png)


</details>

<details>
<summary>Tablet:</summary>

Before: 

![Capture d’écran 2023-03-24 à 08 39 07](https://user-images.githubusercontent.com/35332974/227457889-d2ea003b-a5af-428c-b29d-2b00d5312dad.png)

After: 

![Capture d’écran 2023-03-24 à 08 37 40](https://user-images.githubusercontent.com/35332974/227457900-1a7d5fae-d0ea-4815-bdf8-64303e3e1505.png)

</details>


<details>
<summary>Mobile: (changes not visible on 414px screen size)</summary>

![Capture d’écran 2023-03-24 à 08 52 20](https://user-images.githubusercontent.com/35332974/227458502-31916fe8-f527-4970-a160-9db74f9623f0.png)

![Capture d’écran 2023-03-24 à 08 52 31](https://user-images.githubusercontent.com/35332974/227458519-0e260648-6da6-4c1d-aceb-becbe650dcb9.png)

</details>



