### PR TITLE
Style/add layout mixins

### DIFF
--- a/src/component/toolbar/toolbar.scss
+++ b/src/component/toolbar/toolbar.scss
@@ -1,24 +1,9 @@
 @import '@/style/mixins.scss';
 
 .okp4-dataverse-portal-toolbar-main {
+  @include twelve-column-layout;
   justify-items: end;
   align-items: center;
-
-  @include use-breakpoints(('mobile')) {
-    @include grid-container($colsNb: 6, $gutter: 16px);
-  }
-
-  @include use-breakpoints(('tablet')) {
-    @include grid-container($colsNb: 8, $gutter: 16px);
-  }
-
-  @include use-breakpoints(('desktop')) {
-    @include grid-container($gutter: 34px);
-  }
-
-  @include use-breakpoints(('large-desktop')) {
-    @include grid-container($gutter: 48px);
-  }
 
   .okp4-dataverse-portal-burger-menu {
     @include grid-item($colStart: 1, $colEnd: 2, $rowStart: 1, $rowEnd: 1);

--- a/src/main.scss
+++ b/src/main.scss
@@ -58,6 +58,7 @@ p {
   }
 
   .okp4-dataverse-portal-page-layout {
+    @include twelve-column-layout;
     flex: 1;
     grid-template-rows: max-content;
     width: 100%;
@@ -65,8 +66,6 @@ p {
     row-gap: 15px;
 
     @include use-breakpoints(('mobile')) {
-      @include grid-container($colsNb: 6, $gutter: 16px);
-
       &.expanded-sidebar {
         @include blurred-page(1px);
         position: absolute;
@@ -75,7 +74,6 @@ p {
     }
 
     @include use-breakpoints(('tablet')) {
-      @include grid-container($colsNb: 8, $gutter: 16px);
       row-gap: 48px;
 
       &.expanded-sidebar {
@@ -83,14 +81,6 @@ p {
         position: absolute;
         left: 376px;
       }
-    }
-
-    @include use-breakpoints(('desktop')) {
-      @include grid-container($gutter: 34px);
-    }
-
-    @include use-breakpoints(('large-desktop')) {
-      @include grid-container($gutter: 48px);
     }
 
     .okp4-dataverse-portal-toolbar-wrapper,

--- a/src/page/dataverse/dataverse.scss
+++ b/src/page/dataverse/dataverse.scss
@@ -4,7 +4,6 @@
 
 .okp4-dataverse-portal-dataverse-page-main {
   @include with-theme() {
-    @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: auto);
     @include grid-container($gutter: 48px);
     color: themed('text');
     grid-auto-rows: max-content;

--- a/src/page/home/home.scss
+++ b/src/page/home/home.scss
@@ -4,7 +4,6 @@
 
 .okp4-dataverse-portal-home-page-main {
   @include with-theme() {
-    @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: auto);
     row-gap: 30px;
 
     @include use-breakpoints(('mobile', 'tablet')) {
@@ -57,7 +56,6 @@
         -webkit-text-fill-color: transparent;
 
         @include use-breakpoints(('tablet', 'mobile')) {
-          @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);
           justify-self: center;
           margin-bottom: 4px;
         }

--- a/src/page/home/home.scss
+++ b/src/page/home/home.scss
@@ -4,44 +4,15 @@
 
 .okp4-dataverse-portal-home-page-main {
   @include with-theme() {
+    @include twelve-column-layout;
     row-gap: 30px;
 
     @include use-breakpoints(('mobile', 'tablet')) {
       row-gap: 40px;
     }
 
-    @include use-breakpoints(('mobile')) {
-      @include grid-container($colsNb: 6, $gutter: 16px);
-    }
-
-    @include use-breakpoints(('tablet')) {
-      @include grid-container($colsNb: 8, $gutter: 16px);
-    }
-
-    @include use-breakpoints(('desktop')) {
-      @include grid-container($gutter: 34px);
-    }
-
-    @include use-breakpoints(('large-desktop')) {
-      @include grid-container($gutter: 48px);
-    }
-
     .okp4-dataverse-portal-home-page-block-container {
-      @include use-breakpoints(('desktop')) {
-        @include grid-container($gutter: 34px);
-      }
-
-      @include use-breakpoints(('large-desktop')) {
-        @include grid-container($gutter: 48px);
-      }
-
-      @include use-breakpoints(('mobile')) {
-        @include grid-container($colsNb: 6, $gutter: 16px);
-      }
-
-      @include use-breakpoints(('tablet')) {
-        @include grid-container($colsNb: 8, $gutter: 16px);
-      }
+      @include twelve-column-layout;
 
       h1 {
         @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -46,3 +46,21 @@
 @mixin transition-bg-color {
   transition: background-color 200ms ease-in-out;
 }
+
+@mixin twelve-column-layout {
+  @include use-breakpoints(('mobile')) {
+    @include grid-container($colsNb: 6, $gutter: 16px);
+  }
+
+  @include use-breakpoints(('tablet')) {
+    @include grid-container($colsNb: 8, $gutter: 16px);
+  }
+
+  @include use-breakpoints(('desktop')) {
+    @include grid-container($gutter: 34px);
+  }
+
+  @include use-breakpoints(('large-desktop')) {
+    @include grid-container($gutter: 48px);
+  }
+}

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -48,6 +48,8 @@
 }
 
 @mixin twelve-column-layout {
+  row-gap: 40px;
+
   @include use-breakpoints(('mobile')) {
     @include grid-container($colsNb: 6, $gutter: 16px);
   }

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -64,3 +64,26 @@
     @include grid-container($gutter: 48px);
   }
 }
+
+@mixin bi-column-item($side) {
+  @if not($side == 'left' or $side == 'right') {
+    @error '#{$side} is not a valid argument, accepted arguments: left, right';
+  }
+  @if ($side == 'left') {
+    @include use-breakpoints(('mobile', 'tablet')) {
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
+    }
+
+    @include use-breakpoints(('desktop', 'large-desktop')) {
+      @include grid-item($colStart: 1, $colEnd: 7, $rowStart: auto, $rowEnd: auto);
+    }
+  } @else if ($side == 'right') {
+    @include use-breakpoints(('mobile', 'tablet')) {
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
+    }
+
+    @include use-breakpoints(('desktop', 'large-desktop')) {
+      @include grid-item($colStart: 7, $colEnd: 13, $rowStart: auto, $rowEnd: auto);
+    }
+  }
+}


### PR DESCRIPTION
This adds two sass mixins: `twelve-column-layout` and `bi-column-item($side)` following this issue:
- #131 

`twelve-column-layout` groups the current layout based
`bi-column-item($side)` facilitates positioning items in a two column layout, using the `twelve-column-layout`.

This PR also removes redundant grid-item includes rendered redundant by the introduction of the `okp4-dataverse-portal-page-wrapper` in 
- #118 

In the images below the red element represents a left bi-column-item and the green element a right bi-column-item

<details>
<summary>1920px</summary>

![127 0 0 1_5173_test (5)](https://user-images.githubusercontent.com/75730728/228179528-c230f0cb-3012-4e33-9d79-8b5e04fbaa26.png)


</details>

<details>
<summary>1440px</summary>

![127 0 0 1_5173_test](https://user-images.githubusercontent.com/75730728/227989451-d6ce5d4f-06ba-470e-8a1f-0590c79bd6a6.png)


</details>

<details>
<summary>768px</summary>

![127 0 0 1_5173_test (3)](https://user-images.githubusercontent.com/75730728/228158955-f275f339-da0c-4b3d-8a8c-088c9794e9a3.png)

</details>

<details>
<summary>375px</summary>

![127 0 0 1_5173_test (4)](https://user-images.githubusercontent.com/75730728/228158983-3879d2a0-8508-4d8b-bef2-e448ee022669.png)


</details>