### PR TITLE
fix(app): toolbar disappears on mobile scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ const App: FC = () => {
   const isSidebarExpanded = useAppStore(store => store.isSidebarExpanded)
 
   return (
-    <div className={`theme--${theme}`} style={{ minHeight: 'inherit' }}>
+    <div className={`theme--${theme}`} style={{ height: 'inherit' }}>
       <div className="okp4-dataverse-portal-main-layout">
         <Sidebar />
         <div

--- a/src/main.scss
+++ b/src/main.scss
@@ -25,14 +25,14 @@
 
 html,
 body {
-  min-height: 100vh;
+  height: 100%;
   margin: 0;
   padding: 0;
   width: 100%;
 }
 
 #root {
-  min-height: inherit;
+  height: inherit;
 }
 
 p,
@@ -48,8 +48,7 @@ p {
 
 .okp4-dataverse-portal-main-layout {
   @include with-theme() {
-    min-height: inherit;
-    max-height: 100vh;
+    height: inherit;
     display: flex;
     width: 100%;
     background-color: themed('background');


### PR DESCRIPTION
Fixes the bug raised in
- #132 

The bug is due to the fact that on mobile the address bar is counted as part of the viewport, making 100vh larger than the actual window. For this reason it is recommended to avoid using 100vh: https://dev.to/admitkard/mobile-issue-with-100vh-height-100-100vh-3-solutions-3nae