### PR TITLE
Feat: add dataverse items dynamic routes

### DIFF
--- a/src/component/card/dataverseCard/dataverseCard.tsx
+++ b/src/component/card/dataverseCard/dataverseCard.tsx
@@ -1,22 +1,25 @@
 import type { FC } from 'react'
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 import './dataverseCard.scss'
 import { Card } from '@/component/card/card'
 import { Button } from '@/component/button/button'
 import { Tag } from '@/component/tag/tag'
 import ReactMarkdown from 'react-markdown'
 import type { ColorVariant } from '@/component/tag/tag'
-import { useTranslation } from 'react-i18next'
 
 type DataverseItem = 'dataspace' | 'dataset' | 'service'
 
 export type DataverseCardProps = {
+  id: string
   type: DataverseItem
   label: string
   description: string
 }
 
-export const DataverseCard: FC<DataverseCardProps> = ({ type, label, description }) => {
+export const DataverseCard: FC<DataverseCardProps> = ({ id, type, label, description }) => {
+  const navigate = useNavigate()
   const { t } = useTranslation('common')
 
   const renderTagColor = useCallback((type: DataverseItem): ColorVariant => {
@@ -36,6 +39,10 @@ ${description}`,
     []
   )
 
+  const handleDataverseItemDetails = useCallback((): void => {
+    navigate(`/dataverse/${type}/${id}`)
+  }, [id, navigate, type])
+
   return (
     <Card>
       <div className="okp4-dataverse-portal-dataverse-card-main">
@@ -44,7 +51,7 @@ ${description}`,
           <div className="okp4-dataverse-portal-dataverse-description">
             <ReactMarkdown>{renderItemContent(label, description)}</ReactMarkdown>
           </div>
-          <Button disabled label={t('actions.details')} />
+          <Button label={t('actions.details')} onClick={handleDataverseItemDetails} />
         </div>
       </div>
     </Card>

--- a/src/component/card/dataverseItemCard/dataverseItemCard.scss
+++ b/src/component/card/dataverseItemCard/dataverseItemCard.scss
@@ -2,7 +2,7 @@
 @import '@/style/mixins.scss';
 @import '@/style/theme.scss';
 
-.okp4-dataverse-portal-dataverse-card-main {
+.okp4-dataverse-portal-dataverse-item-card-main {
   @include with-theme {
     width: 100%;
     height: 100%;
@@ -27,7 +27,7 @@
       -webkit-box-orient: vertical;
     }
 
-    .okp4-dataverse-portal-dataverse-card-content {
+    .okp4-dataverse-portal-dataverse-item-card-content {
       width: 84%;
       padding-top: 55px;
       padding-bottom: 24px;

--- a/src/component/card/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/component/card/dataverseItemCard/dataverseItemCard.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import './dataverseCard.scss'
+import './DataverseItemCard.scss'
 import { Card } from '@/component/card/card'
 import { Button } from '@/component/button/button'
 import { Tag } from '@/component/tag/tag'
@@ -11,14 +11,14 @@ import type { ColorVariant } from '@/component/tag/tag'
 
 type DataverseItem = 'dataspace' | 'dataset' | 'service'
 
-export type DataverseCardProps = {
+export type DataverseItemCardProps = {
   id: string
   type: DataverseItem
   label: string
   description: string
 }
 
-export const DataverseCard: FC<DataverseCardProps> = ({ id, type, label, description }) => {
+export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label, description }) => {
   const navigate = useNavigate()
   const { t } = useTranslation('common')
 
@@ -45,9 +45,9 @@ ${description}`,
 
   return (
     <Card>
-      <div className="okp4-dataverse-portal-dataverse-card-main">
+      <div className="okp4-dataverse-portal-dataverse-item-card-main">
         <Tag colorVariant={renderTagColor(type)} label={t(`resources.${type}`)} />
-        <div className="okp4-dataverse-portal-dataverse-card-content">
+        <div className="okp4-dataverse-portal-dataverse-item-card-content">
           <div className="okp4-dataverse-portal-dataverse-description">
             <ReactMarkdown>{renderItemContent(label, description)}</ReactMarkdown>
           </div>

--- a/src/page/dataverse/dataset/dataset.tsx
+++ b/src/page/dataverse/dataset/dataset.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getResourceDetails } from '../dataverse'
+import type { DataverseItemDetails } from '../dataverse'
+
+const Dataset = (): JSX.Element => {
+  const { id } = useParams<string>()
+  const [dataset, setDataset] = useState<DataverseItemDetails | undefined>()
+
+  useEffect(() => {
+    id && setDataset(getResourceDetails(id))
+  }, [id])
+  return dataset ? <p> {dataset.label}</p> : <p>Dataset not found</p>
+}
+
+export default Dataset

--- a/src/page/dataverse/dataset/dataset.tsx
+++ b/src/page/dataverse/dataset/dataset.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import type { Option } from 'fp-ts/Option'
+import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '../dataverse'
 import type { DataverseItemDetails } from '../dataverse'
 
 const Dataset = (): JSX.Element => {
   const { id } = useParams<string>()
-  const [dataset, setDataset] = useState<DataverseItemDetails | undefined>()
+  const [dataset, setDataset] = useState<Option<DataverseItemDetails>>(none)
 
   useEffect(() => {
     id && setDataset(getResourceDetails(id))
   }, [id])
-  return dataset ? <p> {dataset.label}</p> : <p>Dataset not found</p>
+
+  return match(
+    () => <p>Dataset not found</p>,
+    (dataset: DataverseItemDetails) => <p>{dataset.label}</p>
+  )(dataset)
 }
 
 export default Dataset

--- a/src/page/dataverse/dataset/dataset.tsx
+++ b/src/page/dataverse/dataset/dataset.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
-import { getResourceDetails } from '../dataverse'
-import type { DataverseItemDetails } from '../dataverse'
+import { getResourceDetails } from '@/page/dataverse/dataverse'
+import type { DataverseItemDetails } from '@/page/dataverse/dataverse'
 
 const Dataset = (): JSX.Element => {
   const { id } = useParams<string>()

--- a/src/page/dataverse/dataspace/dataspace.tsx
+++ b/src/page/dataverse/dataspace/dataspace.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
-import { getResourceDetails } from '../dataverse'
-import type { DataverseItemDetails } from '../dataverse'
+import { getResourceDetails } from '@/page/dataverse/dataverse'
+import type { DataverseItemDetails } from '@/page/dataverse/dataverse'
 
 const Dataspace = (): JSX.Element => {
   const { id } = useParams<string>()

--- a/src/page/dataverse/dataspace/dataspace.tsx
+++ b/src/page/dataverse/dataspace/dataspace.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import type { Option } from 'fp-ts/Option'
+import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '../dataverse'
 import type { DataverseItemDetails } from '../dataverse'
 
 const Dataspace = (): JSX.Element => {
   const { id } = useParams<string>()
-  const [dataspace, setDataspace] = useState<DataverseItemDetails | undefined>()
+  const [dataspace, setDataspace] = useState<Option<DataverseItemDetails>>(none)
 
   useEffect(() => {
     id && setDataspace(getResourceDetails(id))
   }, [id])
-  return dataspace ? <p>{dataspace.label}</p> : <p>Dataspace not found</p>
+
+  return match(
+    () => <p>Dataspace not found</p>,
+    (dataspace: DataverseItemDetails) => <p>{dataspace.label}</p>
+  )(dataspace)
 }
 
 export default Dataspace

--- a/src/page/dataverse/dataspace/dataspace.tsx
+++ b/src/page/dataverse/dataspace/dataspace.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getResourceDetails } from '../dataverse'
+import type { DataverseItemDetails } from '../dataverse'
+
+const Dataspace = (): JSX.Element => {
+  const { id } = useParams<string>()
+  const [dataspace, setDataspace] = useState<DataverseItemDetails | undefined>()
+
+  useEffect(() => {
+    id && setDataspace(getResourceDetails(id))
+  }, [id])
+  return dataspace ? <p>{dataspace.label}</p> : <p>Dataspace not found</p>
+}
+
+export default Dataspace

--- a/src/page/dataverse/dataverse.tsx
+++ b/src/page/dataverse/dataverse.tsx
@@ -13,7 +13,7 @@ import './dataverse.scss'
 type DataverseItem = 'dataspace' | 'dataset' | 'service'
 type FilterLabel = 'dataspaces' | 'datasets' | 'services' | 'all'
 type FilterValue = DataverseItem | 'all'
-type DataverseItemDetails = DataverseCardProps
+export type DataverseItemDetails = DataverseCardProps
 
 type Filter = {
   label: FilterLabel
@@ -46,18 +46,21 @@ const filters: Filter[] = [
 
 const dataverseItems: DataverseItemDetails[] = [
   {
+    id: '1',
     type: 'dataspace',
     label: 'Rhizome',
     description:
       'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.'
   },
   {
+    id: '2',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 DEPARTMENT',
     description:
       'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
+    id: '3',
     type: 'service',
     label: 'Data Connector',
     description:
@@ -65,99 +68,111 @@ const dataverseItems: DataverseItemDetails[] = [
   },
   {
     type: 'dataset',
+    id: '4',
     label:
       'Crop and crop group reference table of the Graphic Parcel Register (Registre Parcellaire Graphique)',
     description:
       'Table specific to the distribution of the Graphic Parcel Register (Registre Parcellaire Graphique)): The notion of crop group in this table does not correspond to the notion of crop group of the CAP regulation nor to that of the ISIS reference systems. In this table, each crop code is explained by a label and linked to a crop group code and its label.'
   },
   {
+    id: '5',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 REGION',
     description:
       'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
+    id: '6',
     type: 'service',
     label: 'Data Refactor',
     description:
       'The Data Refactor tool allows you to edit and modify a data set in order to standardize it.'
   },
   {
+    id: '7',
     type: 'dataset',
     label: 'FRANCE : REGION - DEPARTMENT - CITY',
     description:
       'This dataset is obtained by joining 3 ADMIN EXPRESS datasets containing the different layers of the French territory: Region, Department and City.'
   },
   {
+    id: '8',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2020 DEPARTMENT',
     description:
       'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
+    id: '9',
     type: 'service',
     label: 'Data Join Tabular',
     description:
       'The Data Join Tabular tool allows you to join two datasets containing common values to provide new information.'
   },
   {
+    id: '10',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 CITY',
     description:
       'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
+    id: '11',
     type: 'dataset',
     label: 'RPG FRANCE 2020',
     description:
       'The graphical parcel register is a geographic database used as a reference for the instruction of Common Agricultural Policy (CAP) subsidies. The anonymized version distributed here as part of the public service for making reference data available contains the graphic data of parcels (since 2015) with their main crop. These data are produced by the Agency of Services and Payment (ASP) since 2007'
   },
   {
+    id: '12',
     type: 'service',
     label: 'Data Grouping',
     description: 'The Data Grouping tool allows you to organize identical data into groups.'
   },
   {
+    id: '13',
     type: 'dataset',
     label: 'AGRESTE 2020',
     description:
       'Annual agricultural statistics, consisting of the areas, yields and production of the French territory.'
   },
   {
+    id: '14',
     type: 'dataset',
     label: 'RPG AGRESTE 2020',
     description:
       'Data set resulting from the join between RPG and AGRESTE data. Obtained through a sequence of data processing using the OKP4 protocol.'
   },
+  { id: '15', type: 'service', label: 'Storage', description: 'Data storage service' },
   {
-    type: 'service',
-    label: 'Storage',
-    description: 'Data storage service'
-  },
-  {
+    id: '16',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2020 REGION',
     description:
       'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
+    id: '17',
     type: 'dataset',
     label: 'Reference table of NAF Rev2 codes',
     description:
       'The French Nomenclature of Activities (NAF) is a nomenclature of productive economic activities, mainly developed to facilitate the organization of economic and social information.'
   },
   {
+    id: '18',
     type: 'service',
     label: 'Data Join Geospatial',
     description: 'The Data Join Geospatial tool allows to join two georeferenced datasets.'
   },
   {
+    id: '19',
     type: 'dataset',
     label: 'BASE SIRENE - NAF',
     description:
       'This dataset is obtained using the join between the SIRENE database and the NAF code reference table to obtain information on the activity of establishments.'
   },
   {
+    id: '20',
     type: 'dataset',
     label: 'SIRENE database - agriculture, forestry and fishing',
     description:
@@ -299,8 +314,8 @@ const Dataverse = (): JSX.Element => {
             />
           )}
           <div className="okp4-dataverse-portal-dataverse-page-cards-container">
-            {dataverseResources.map(({ type, label, description }) => (
-              <DataverseCard description={description} key={label} label={label} type={type} />
+            {dataverseResources.map(({ id, type, label, description }) => (
+              <DataverseCard description={description} id={id} key={id} label={label} type={type} />
             ))}
           </div>
         </div>

--- a/src/page/dataverse/dataverse.tsx
+++ b/src/page/dataverse/dataverse.tsx
@@ -180,6 +180,10 @@ const dataverseItems: DataverseItemDetails[] = [
   }
 ]
 
+export const getResourceDetails = (id: string): DataverseItemDetails | undefined => {
+  return dataverseItems.find(item => item.id === id)
+}
+
 const renderMobileTitleFilters = (label: string, toggleMobileFilters: () => void): JSX.Element => (
   <div className="okp4-dataverse-portal-dataverse-page-filters-mobile">
     <div

--- a/src/page/dataverse/dataverse.tsx
+++ b/src/page/dataverse/dataverse.tsx
@@ -1,5 +1,5 @@
-import { DataverseCard } from '@/component/card/dataverseCard/dataverseCard'
-import type { DataverseCardProps } from '@/component/card/dataverseCard/dataverseCard'
+import { DataverseItemCard } from '@/component/card/DataverseItemCard/DataverseItemCard'
+import type { DataverseItemCardProps } from '@/component/card/DataverseItemCard/DataverseItemCard'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useBreakpoint } from '@/hook/useBreakpoint'
@@ -13,7 +13,7 @@ import './dataverse.scss'
 type DataverseItem = 'dataspace' | 'dataset' | 'service'
 type FilterLabel = 'dataspaces' | 'datasets' | 'services' | 'all'
 type FilterValue = DataverseItem | 'all'
-export type DataverseItemDetails = DataverseCardProps
+export type DataverseItemDetails = DataverseItemCardProps
 
 type Filter = {
   label: FilterLabel
@@ -319,7 +319,13 @@ const Dataverse = (): JSX.Element => {
           )}
           <div className="okp4-dataverse-portal-dataverse-page-cards-container">
             {dataverseResources.map(({ id, type, label, description }) => (
-              <DataverseCard description={description} id={id} key={id} label={label} type={type} />
+              <DataverseItemCard
+                description={description}
+                id={id}
+                key={id}
+                label={label}
+                type={type}
+              />
             ))}
           </div>
         </div>

--- a/src/page/dataverse/dataverse.tsx
+++ b/src/page/dataverse/dataverse.tsx
@@ -1,9 +1,11 @@
-import { DataverseItemCard } from '@/component/card/DataverseItemCard/DataverseItemCard'
-import type { DataverseItemCardProps } from '@/component/card/DataverseItemCard/DataverseItemCard'
+import * as A from 'fp-ts/Array'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { pipe } from 'fp-ts/lib/function'
 import { useBreakpoint } from '@/hook/useBreakpoint'
 import { useAppStore } from '@/store/appStore'
+import { DataverseItemCard } from '@/component/card/DataverseItemCard/DataverseItemCard'
+import type { DataverseItemCardProps } from '@/component/card/DataverseItemCard/DataverseItemCard'
 import { Button } from '@/component/button/button'
 import Chip from '@/component/chip/chip'
 import { Icon } from '@/component/icon/icon'
@@ -180,9 +182,11 @@ const dataverseItems: DataverseItemDetails[] = [
   }
 ]
 
-export const getResourceDetails = (id: string): DataverseItemDetails | undefined => {
-  return dataverseItems.find(item => item.id === id)
-}
+export const getResourceDetails = (id: string): Option<DataverseItemDetails> =>
+  pipe(
+    dataverseItems,
+    A.findFirst(item => item.id === id)
+  )
 
 const renderMobileTitleFilters = (label: string, toggleMobileFilters: () => void): JSX.Element => (
   <div className="okp4-dataverse-portal-dataverse-page-filters-mobile">

--- a/src/page/dataverse/service/service.tsx
+++ b/src/page/dataverse/service/service.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import type { Option } from 'fp-ts/Option'
+import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '../dataverse'
 import type { DataverseItemDetails } from '../dataverse'
 
 const Service = (): JSX.Element => {
   const { id } = useParams<string>()
-  const [service, setService] = useState<DataverseItemDetails | undefined>()
+  const [service, setService] = useState<Option<DataverseItemDetails>>(none)
 
   useEffect(() => {
     id && setService(getResourceDetails(id))
   }, [id])
-  return service ? <p>{service.label}</p> : <p>Service not found</p>
+
+  return match(
+    () => <p>Service not found</p>,
+    (service: DataverseItemDetails) => <p>{service.label}</p>
+  )(service)
 }
 
 export default Service

--- a/src/page/dataverse/service/service.tsx
+++ b/src/page/dataverse/service/service.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getResourceDetails } from '../dataverse'
+import type { DataverseItemDetails } from '../dataverse'
+
+const Service = (): JSX.Element => {
+  const { id } = useParams<string>()
+  const [service, setService] = useState<DataverseItemDetails | undefined>()
+
+  useEffect(() => {
+    id && setService(getResourceDetails(id))
+  }, [id])
+  return service ? <p>{service.label}</p> : <p>Service not found</p>
+}
+
+export default Service

--- a/src/page/dataverse/service/service.tsx
+++ b/src/page/dataverse/service/service.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
-import { getResourceDetails } from '../dataverse'
-import type { DataverseItemDetails } from '../dataverse'
+import { getResourceDetails } from '@/page/dataverse/dataverse'
+import type { DataverseItemDetails } from '@/page/dataverse/dataverse'
 
 const Service = (): JSX.Element => {
   const { id } = useParams<string>()

--- a/src/page/home/explore/explore.tsx
+++ b/src/page/home/explore/explore.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import '../i18n/index'
 import './explore.scss'
@@ -10,39 +9,42 @@ import { Icon } from '@/component/icon/icon'
 import { NavLink } from 'react-router-dom'
 import { routes } from '@/routes'
 
+const exploreItems: DataverseCardProps[] = [
+  {
+    id: '1',
+    type: 'dataspace',
+    label: 'Rhizome',
+    description: 'Agriculture, Food, Environment and Forestry'
+  },
+  {
+    id: '13',
+    type: 'dataset',
+    label: 'Agreste 2020',
+    description: 'Agriculture, Food, Environment and Forestry'
+  },
+  {
+    id: '11',
+    type: 'dataset',
+    label: 'Graphical Plot Registry France 2020',
+    description: 'Agriculture, Food, Environment and Forestry'
+  },
+  {
+    id: '3',
+    type: 'service',
+    label: 'Data connector',
+    description: 'Data Integration'
+  }
+]
+
 export const Explore: FC = () => {
   const { t } = useTranslation('home')
-  const exploreItems: DataverseCardProps[] = useMemo(
-    () => [
-      {
-        type: 'dataspace',
-        label: 'Rhizome',
-        description: 'Agriculture, Food, Environment and Forestry'
-      },
-      {
-        type: 'dataset',
-        label: 'Agreste 2020',
-        description: 'Agriculture, Food, Environment and Forestry'
-      },
-      {
-        type: 'dataset',
-        label: 'Graphical Plot Registry France 2020',
-        description: 'Agriculture, Food, Environment and Forestry'
-      },
-      {
-        type: 'service',
-        label: 'Data connector',
-        description: 'Data Integration'
-      }
-    ],
-    []
-  )
+
   return (
     <>
       <h1>{t('home.blocks.explore.label')}</h1>
-      {exploreItems.map(({ type, description, label }) => (
+      {exploreItems.map(({ id, type, description, label }) => (
         <div className="okp4-dataverse-portal-home-page-explore-card-wrapper" key={label}>
-          <DataverseCard description={description} label={label} type={type} />
+          <DataverseCard description={description} id={id} label={label} type={type} />
         </div>
       ))}
       <NavLink

--- a/src/page/home/explore/explore.tsx
+++ b/src/page/home/explore/explore.tsx
@@ -2,14 +2,14 @@ import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import '../i18n/index'
 import './explore.scss'
-import type { DataverseCardProps } from '@/component/card/dataverseCard/dataverseCard'
-import { DataverseCard } from '@/component/card/dataverseCard/dataverseCard'
+import type { DataverseItemCardProps } from '@/component/card/DataverseItemCard/DataverseItemCard'
+import { DataverseItemCard } from '@/component/card/DataverseItemCard/DataverseItemCard'
 import { Button } from '@/component/button/button'
 import { Icon } from '@/component/icon/icon'
 import { NavLink } from 'react-router-dom'
 import { routes } from '@/routes'
 
-const exploreItems: DataverseCardProps[] = [
+const exploreItems: DataverseItemCardProps[] = [
   {
     id: '1',
     type: 'dataspace',
@@ -44,7 +44,7 @@ export const Explore: FC = () => {
       <h1>{t('home.blocks.explore.label')}</h1>
       {exploreItems.map(({ id, type, description, label }) => (
         <div className="okp4-dataverse-portal-home-page-explore-card-wrapper" key={label}>
-          <DataverseCard description={description} id={id} label={label} type={type} />
+          <DataverseItemCard description={description} id={id} label={label} type={type} />
         </div>
       ))}
       <NavLink

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,9 +1,15 @@
 import { Home } from '@/page/home/home'
 import Dataverse from '@/page/dataverse/dataverse'
+import Dataspace from '@/page/dataverse/dataspace/dataspace'
+import Dataset from '@/page/dataverse/dataset/dataset'
+import Service from '@/page/dataverse/service/service'
 
 export enum routes {
   home = '/',
-  dataverse = '/dataverse'
+  dataverse = 'dataverse',
+  dataspace = 'dataverse/dataspace/:id',
+  dataset = 'dataverse/dataset/:id',
+  service = 'dataverse/service/:id'
 }
 
 export type Route = {
@@ -22,5 +28,20 @@ export const appRoutes: Route[] = [
     id: 'dataverse',
     path: routes.dataverse,
     element: <Dataverse />
+  },
+  {
+    id: 'dataspace',
+    path: routes.dataspace,
+    element: <Dataspace />
+  },
+  {
+    id: 'dataset',
+    path: routes.dataset,
+    element: <Dataset />
+  },
+  {
+    id: 'service',
+    path: routes.service,
+    element: <Service />
   }
 ]


### PR DESCRIPTION
The PR implements this [issue](https://github.com/okp4/dataverse-portal/issues/97).
It enables clic on dataverse card buttons located in Home and in Explore pages.
For the moment, if the URL id param doesn't exist, a message "Dataspace/Dataset/Service is not found" appears while waiting for the layout of the 404 page. 
🤔 The data as well as the way of querying these data is going to change, a refactor will be done at this time to decouple the elements.