### PR TITLE
fix(chip): text wrapping on small screen

### DIFF
--- a/src/component/chip/chip.scss
+++ b/src/component/chip/chip.scss
@@ -22,7 +22,6 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      white-space: pre;
 
       &:not(.okp4-dataverse-portal-chip-icon) {
         justify-content: center;
@@ -50,11 +49,16 @@
         @include noto-sans(400);
         color: themed(chip);
         width: 100%;
+        max-width: 240px;
         font-size: 16px;
         line-height: 24px;
         word-wrap: break-word;
         overflow: hidden;
         text-overflow: ellipsis;
+        /* stylelint-disable-next-line value-no-vendor-prefix */
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
 
         &.selected {
           @include noto-sans(700);

--- a/src/page/dataverse/dataverse.scss
+++ b/src/page/dataverse/dataverse.scss
@@ -67,21 +67,23 @@
           @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
           display: flex;
           flex-wrap: wrap;
+          align-items: center;
+          column-gap: 8px;
+          row-gap: 16px;
 
           @include use-breakpoints(('mobile', 'tablet')) {
-            @include grid-container($colsNb: 8, $gutter: 12px);
             display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, auto));
+            gap: 12px;
           }
 
           .okp4-dataverse-portal-dataverse-page-filter {
             width: fit-content;
             height: fit-content;
-            margin: 0 8px 16px 0;
             display: flex;
             flex-direction: column;
 
             @include use-breakpoints(('mobile', 'tablet')) {
-              grid-column: auto / span 2;
               width: 100%;
               height: 110px;
               justify-content: center;
@@ -107,7 +109,7 @@
             }
 
             @include use-breakpoints(('large-desktop')) {
-              margin-right: 16px;
+              margin-right: 8px;
             }
           }
         }


### PR DESCRIPTION
Fixing the text wrap issue raised in 
- #88 

<details>
<summary>375px</summary>

![Capture d’écran 2023-03-29 à 10 28 50](https://user-images.githubusercontent.com/75730728/228474309-b383c5ca-db90-4649-b8d2-a56935fe40e5.png)

</details>
<details>
<summary>360px</summary>

![Capture d’écran 2023-03-29 à 10 28 34](https://user-images.githubusercontent.com/75730728/228474312-f48d5d02-220b-4a87-8a60-230341f1432d.png)

</details>

OBS I've added extra text in the images to show the behaviour of the chip component when the text overflows.
