### PR TITLE
Feat/button size property

### DIFF
--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -36,13 +36,6 @@
   }
 }
 
-@mixin disabled {
-  cursor: unset;
-  background: themed('neutral-variant-1');
-  border-color: themed('neutral-variant-1');
-  color: themed('neutral');
-}
-
 .okp4-dataverse-portal-button-main {
   @include with-theme {
     cursor: pointer;

--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -2,12 +2,11 @@
 @import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins.scss';
 
-@mixin button($border-color, $content-color, $background-color, $box-shadow, $hover-color) {
+@mixin button($content-color, $background-color, $box-shadow, $hover-color) {
   @include transition-bg-color;
   display: flex;
   justify-content: center;
   width: 100%;
-  border: 1px solid $border-color;
   color: $content-color;
   border-radius: 12px;
   background-color: $background-color;
@@ -26,7 +25,6 @@
   &.disabled {
     cursor: unset;
     background: themed('neutral-variant-1');
-    border-color: themed('neutral-variant-1');
     color: themed('neutral');
     box-shadow: none;
   }
@@ -43,11 +41,10 @@
   @include with-theme {
     cursor: pointer;
     padding: unset;
-    box-sizing: border-box;
+    border: unset;
 
     &.primary {
       @include button(
-        $border-color: themed('secondary-color'),
         $content-color: themed('primary-text'),
         $background-color: themed('secondary-color'),
         $box-shadow: 0 4px 12px rgb(themed('secondary-color'), 0.6),
@@ -57,7 +54,6 @@
 
     &.secondary {
       @include button(
-        $border-color: themed('primary-color'),
         $content-color: themed('primary-text'),
         $background-color: themed('primary-color'),
         $box-shadow: 0 4px 12px rgb(themed('primary-color'), 0.6),
@@ -72,7 +68,6 @@
     }
 
     &.tertiary {
-      border: unset;
       color: themed('text');
       border-radius: 12px;
       background: themed('tertiary-button-background');
@@ -84,13 +79,17 @@
 
     &.outlined-tertiary {
       @include button(
-        $border-color: themed('secondary-color'),
         $content-color: themed('secondary-color'),
         $background-color: unset,
         $box-shadow: none,
         $hover-color: none
       );
       border-radius: 6px;
+      border: 1px solid themed('secondary-color');
+
+      &.disabled {
+        border-color: themed('neutral-variant-1');
+      }
 
       svg {
         path {

--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -111,24 +111,21 @@
       display: flex;
       align-items: center;
 
-      &.primary {
+      &.small {
+        padding: 8px 16px;
+        gap: 8px;
+      }
+
+      &.large {
         padding: 12px 20px;
         gap: 12px;
       }
 
-      &.secondary {
-        padding: 8px 16px;
-        gap: 12px;
-      }
-
-      &.tertiary {
-        padding: 11px 20px;
-        gap: 10px;
-      }
-
       &.outlined-tertiary {
-        padding: 7px 10px;
-        gap: 6px;
+        &.small {
+          padding: 7px 10px;
+          gap: 6px;
+        }
       }
 
       .okp4-dataverse-portal-button-label {

--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -129,17 +129,16 @@
 
       .okp4-dataverse-portal-button-label {
         @include noto-sans(700);
-        font-size: 11px;
-
-        &.primary,
-        &.secondary {
-          font-size: 16px;
-          line-height: 24px;
-        }
+        font-size: 16px;
+        line-height: 24px;
 
         &.tertiary {
           @include noto-sans(400);
-          font-size: 16px;
+        }
+
+        &.outlined-tertiary {
+          font-size: 11px;
+          line-height: unset;
         }
       }
     }

--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -27,6 +27,12 @@
     background: themed('neutral-variant-1');
     color: themed('neutral');
     box-shadow: none;
+
+    svg {
+      path {
+        fill: themed('neutral');
+      }
+    }
   }
 }
 
@@ -59,12 +65,6 @@
         $box-shadow: 0 4px 12px rgb(themed('primary-color'), 0.6),
         $hover-color: themed('primary-color-variant-2')
       );
-
-      svg {
-        path {
-          fill: themed('secondary-color-variant-1');
-        }
-      }
     }
 
     &.tertiary {

--- a/src/ui/component/button/button.tsx
+++ b/src/ui/component/button/button.tsx
@@ -13,6 +13,7 @@ type ButtonProps = {
     endIcon?: JSX.Element
   }
   variant?: 'primary' | 'secondary' | 'tertiary' | 'outlined-tertiary'
+  size?: 'small' | 'large'
 }
 
 export const Button: FC<ButtonProps> = ({
@@ -22,7 +23,8 @@ export const Button: FC<ButtonProps> = ({
   onClick,
   iconButtonOnly,
   icons,
-  variant = 'secondary'
+  variant = 'secondary',
+  size = 'small'
 }) => {
   return (
     <button
@@ -33,7 +35,7 @@ export const Button: FC<ButtonProps> = ({
       onClick={onClick}
     >
       {iconButtonOnly ?? (
-        <div className={classNames('okp4-dataverse-portal-content-container', variant)}>
+        <div className={classNames('okp4-dataverse-portal-content-container', variant, size)}>
           {icons?.startIcon && icons.startIcon}
           {label && (
             <p className={classNames('okp4-dataverse-portal-button-label', variant)}>{label}</p>

--- a/src/ui/component/toolbar/toolbar.tsx
+++ b/src/ui/component/toolbar/toolbar.tsx
@@ -38,7 +38,12 @@ const WalletButton = ({ isSmallScreen, label }: WalletButtonProps): JSX.Element 
         variant="tertiary"
       />
     ) : (
-      <Button icons={{ startIcon: <Icon name="wallet" /> }} label={label} variant="tertiary" />
+      <Button
+        icons={{ startIcon: <Icon name="wallet" /> }}
+        label={label}
+        size="large"
+        variant="tertiary"
+      />
     )}
   </div>
 )

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -319,6 +319,7 @@ const Dataverse = (): JSX.Element => {
               className="okp4-dataverse-portal-dataverse-page-filters-button"
               label={t('filters')}
               onClick={toggleMobileFilters}
+              size="large"
               variant="primary"
             />
           )}

--- a/src/ui/page/home/explore/explore.tsx
+++ b/src/ui/page/home/explore/explore.tsx
@@ -54,6 +54,7 @@ export const Explore: FC = () => {
         <Button
           icons={{ endIcon: <Icon name="arrow-right" /> }}
           label={t('home.blocks.explore.catalog')}
+          size="large"
           variant="primary"
         />
       </NavLink>


### PR DESCRIPTION
This PR adds the `size: 'small' | 'large'` property to the button component, removes wrongly set svg fill as well as adjusts button borders and `label` line-height to correctly reflect the mock-up. This is done in preparation of the following issue
- #72 

Where the secondary button variant require this property (e.g. `DataverseItemCard` uses the small secondary button & the access governance button is a large secondary button).

One thing to take into consideration is that this changes the `gap` in the wallet button from `10px` to `12px`, something that is not according to the mock-up. I've done this for consistency in the property behaviour as I don't see it as a major change.