### PR TITLE
Feat/data space governance description

### DIFF
--- a/src/ui/i18n/translations/common_de.json
+++ b/src/ui/i18n/translations/common_de.json
@@ -7,11 +7,13 @@
     "service": "Dienstleistung",
     "dataspaces": "Datenräume",
     "datasets": "Datensätze",
-    "services": "Dienstleistungen"
+    "services": "Dienstleistungen",
+    "governance": "Führung"
   },
   "actions": {
     "explore": "Erkunden Sie",
-    "details": "Siehe Details"
+    "details": "Siehe Details",
+    "accessGovernance": "Auf Governance zugreifen"
   },
   "filters": "Filter"
 }

--- a/src/ui/i18n/translations/common_en.json
+++ b/src/ui/i18n/translations/common_en.json
@@ -7,11 +7,13 @@
     "service": "Service",
     "dataspaces": "Data Spaces",
     "datasets": "Datasets",
-    "services": "Services"
+    "services": "Services",
+    "governance": "Governance"
   },
   "actions": {
     "explore": "Explore",
-    "details": "See Details"
+    "details": "See Details",
+    "accessGovernance": "Access governance"
   },
   "filters": "Filters"
 }

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -13,7 +13,7 @@
   "actions": {
     "explore": "Explorer",
     "details": "Voir Détails",
-    "accessGovernance": "Accéder à la governance"
+    "accessGovernance": "Accéder à la gouvernance"
   },
   "filters": "Filtres"
 }

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -7,11 +7,13 @@
     "service": "Service",
     "dataspaces": "Data Spaces",
     "datasets": "Données",
-    "services": "Services"
+    "services": "Services",
+    "governance": "Gouvernance"
   },
   "actions": {
     "explore": "Explorer",
-    "details": "Voir Détails"
+    "details": "Voir Détails",
+    "accessGovernance": "Accéder à la governance"
   },
   "filters": "Filtres"
 }

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -28,14 +28,7 @@ const Dataspace = (): JSX.Element => {
   const [dataspace, setDataspace] = useState<Option<DataSpace>>(O.none)
 
   useEffect(() => {
-    const convertToDataSpace = (resource: Option<DataverseItemDetails>): Option<DataSpace> =>
-      pipe(
-        resource,
-        O.filterMap<DataverseItemDetails, DataSpace>(value =>
-          value.type === 'dataspace' ? O.some(value as DataSpace) : O.none
-        )
-      )
-    id && setDataspace(pipe(id, getResourceDetails, convertToDataSpace))
+    pipe(O.fromNullable(id), O.chain(getResourceDetails), O.filter(isDataSpace), setDataspace)
   }, [id])
 
   return O.match(

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -20,6 +20,9 @@ const dataspaceMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
+export const isDataSpace = (resource: DataverseItemDetails): resource is DataSpace =>
+  resource.type === 'dataspace'
+
 const Dataspace = (): JSX.Element => {
   const { id } = useParams<string>()
   const [dataspace, setDataspace] = useState<Option<DataSpace>>(O.none)

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -21,6 +21,16 @@ type DataverseItem = {
   description: string
 }
 
+export type InternationalizedDescription = {
+  en: string
+  fr: string
+  de: string
+}
+
+type Governance = {
+  description: InternationalizedDescription
+}
+
 export type Service = DataverseItem & {
   type: 'service'
 }
@@ -31,6 +41,7 @@ export type Dataset = DataverseItem & {
 
 export type DataSpace = DataverseItem & {
   type: 'dataspace'
+  governance: Governance
 }
 
 export type DataverseItemDetails = DataSpace | Dataset | Service
@@ -70,7 +81,14 @@ const dataverseItems: DataverseItemDetails[] = [
     type: 'dataspace',
     label: 'Rhizome',
     description:
-      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.'
+      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.',
+    governance: {
+      description: {
+        en: 'This first Data Space has a centralized governance: only OKP4 can modify the rules. In this first version, only OKP4 can register data and services. However, any wallet is allowed to download data.',
+        fr: "Ce premier Data Space a une gouvernance centralisée : seul OKP4 peut modifier les règles. Dans cette première version, seul OKP4 peut enregistrer des données et des services. Toutefois, n'importe quel wallet est autorisé à télécharger les données.",
+        de: 'Dieser erste Data Space hat eine zentralisierte Governance: Nur OKP4 kann die Regeln ändern. In dieser ersten Version kann nur OKP4 Daten und Dienste speichern. Allerdings ist es jeder Wallet erlaubt, Daten hochzuladen.'
+      }
+    }
   },
   {
     id: '2',
@@ -197,6 +215,20 @@ const dataverseItems: DataverseItemDetails[] = [
     label: 'SIRENE database - agriculture, forestry and fishing',
     description:
       'This dataset refers to all the agricultural, forestry and fishing companies in France in activity. Obtained through a sequence of data processing using the OKP4 protocol.'
+  },
+  {
+    id: '21',
+    type: 'dataspace',
+    label: 'DS4I',
+    description:
+      "Data Space for Investors (DS4I) is a private Data Space created and maintained by OKP4 Team. DS4I's purpose is to present a simple and user-friendly Proof of Concept to demonstrate for potential investors how OKP4 protocol works based on simple governance rules.",
+    governance: {
+      description: {
+        en: 'DS4I is a private Data Space where resources are only accessible for a group of addresses contained in a dedicated whitelist. Only OKP4 have the authority to edit the Whitelist.',
+        fr: "DS4I est un Data Space privé où les ressources ne sont accessibles que pour un groupe d'adresses de wallets contenues dans une Whitelist dédiée. Seul OKP4 a le droit de modifier cette whitelist.",
+        de: 'DS4I ist ein privater Data Space, in dem die Ressourcen nur für eine Gruppe zugänglich sind. Adressen von Wallets, die in einer dedizierten Whitelist enthalten sind. Nur OKP4 hat das Recht, diese Whitelist zu ändern.'
+      }
+    }
   }
 ]
 

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -22,27 +22,23 @@ type DataverseItem = {
 }
 
 export type InternationalizedDescription = {
-  en: string
-  fr: string
-  de: string
+  [lang in 'en' | 'fr' | 'de']: string
 }
 
 type Governance = {
   description: InternationalizedDescription
 }
 
-export type Service = DataverseItem & {
-  type: 'service'
-}
+type Typed<T extends 'service' | 'dataspace' | 'dataset'> = { type: T }
 
-export type Dataset = DataverseItem & {
-  type: 'dataset'
-}
+export type Service = DataverseItem & Typed<'service'>
 
-export type DataSpace = DataverseItem & {
-  type: 'dataspace'
-  governance: Governance
-}
+export type Dataset = DataverseItem & Typed<'dataset'>
+
+export type DataSpace = DataverseItem &
+  Typed<'dataspace'> & {
+    governance: Governance
+  }
 
 export type DataverseItemDetails = DataSpace | Dataset | Service
 

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -6,17 +6,34 @@ import { pipe } from 'fp-ts/lib/function'
 import { useBreakpoint } from '@/ui/hook/useBreakpoint'
 import { useAppStore } from '@/ui/store/appStore'
 import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
-import type { DataverseItemCardProps } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
 import { Button } from '@/ui/component/button/button'
 import Chip from '@/ui/component/chip/chip'
 import { Icon } from '@/ui/component/icon/icon'
 import type { IconName } from '@/ui/component/icon/icon'
 import './dataverse.scss'
 
-type DataverseItem = 'dataspace' | 'dataset' | 'service'
 type FilterLabel = 'dataspaces' | 'datasets' | 'services' | 'all'
-type FilterValue = DataverseItem | 'all'
-export type DataverseItemDetails = DataverseItemCardProps
+type FilterValue = 'dataspace' | 'dataset' | 'service' | 'all'
+
+type DataverseItem = {
+  id: string
+  label: string
+  description: string
+}
+
+export type Service = DataverseItem & {
+  type: 'service'
+}
+
+export type Dataset = DataverseItem & {
+  type: 'dataset'
+}
+
+export type DataSpace = DataverseItem & {
+  type: 'dataspace'
+}
+
+export type DataverseItemDetails = DataSpace | Dataset | Service
 
 type Filter = {
   label: FilterLabel

--- a/src/ui/view/dataverse/component/governanceDescription/governanceDescription.scss
+++ b/src/ui/view/dataverse/component/governanceDescription/governanceDescription.scss
@@ -1,0 +1,43 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-data-space-governance-description-main {
+  @include with-theme {
+    justify-content: center;
+    padding: 35px 0;
+
+    @include use-breakpoints(('mobile')) {
+      padding-bottom: 20px;
+    }
+
+    .okp4-dataverse-portal-data-space-governance-description-container {
+      display: flex;
+      flex-direction: column;
+      row-gap: 14px;
+      width: 85%;
+
+      @include use-breakpoints(('mobile')) {
+        width: 82%;
+        row-gap: 20px;
+      }
+
+      .okp4-dataverse-portal-data-space-governance-description-title {
+        @include norse-font(700);
+        color: themed('text');
+        font-size: 24px;
+      }
+
+      .okp4-dataverse-portal-data-space-governance-description-description {
+        @include noto-sans(300);
+        color: themed('text');
+        font-size: 16px;
+        line-height: 22px;
+
+        @include use-breakpoints(('tablet', 'desktop', 'large-desktop')) {
+          margin-bottom: 16px;
+        }
+      }
+    }
+  }
+}

--- a/src/ui/view/dataverse/component/governanceDescription/governanceDescription.tsx
+++ b/src/ui/view/dataverse/component/governanceDescription/governanceDescription.tsx
@@ -1,0 +1,43 @@
+import type { FC } from 'react'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { activeLanguageWithDefault } from '@/ui/languages/languages'
+import type { InternationalizedDescription } from '@/ui/page/dataverse/dataverse'
+import { Button } from '@/ui/component/button/button'
+import { Icon } from '@/ui/component/icon/icon'
+import { Card } from '@/ui/component/card/card'
+import './governanceDescription.scss'
+
+type GovernanceDescriptionProps = {
+  description: InternationalizedDescription
+}
+
+export const GovernanceDescription: FC<GovernanceDescriptionProps> = ({
+  description
+}): JSX.Element => {
+  const { t } = useTranslation('common')
+
+  const internationalizedDescription = useCallback((): string => {
+    const { lng } = activeLanguageWithDefault()
+    return description[lng as keyof InternationalizedDescription]
+  }, [description])
+
+  return (
+    <Card mainClassName="okp4-dataverse-portal-data-space-governance-description-main">
+      <div className="okp4-dataverse-portal-data-space-governance-description-container">
+        <h2 className="okp4-dataverse-portal-data-space-governance-description-title">
+          {t('resources.governance')}
+        </h2>
+        <p className="okp4-dataverse-portal-data-space-governance-description-description">
+          {internationalizedDescription()}
+        </p>
+        <Button
+          disabled
+          icons={{ endIcon: <Icon name="arrow-right" /> }}
+          label={t('actions.accessGovernance')}
+          size="large"
+        />
+      </div>
+    </Card>
+  )
+}

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -6,6 +6,8 @@ import { Tags } from '@/ui/view/dataverse/component/tags/tags'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import { GeneralMetadataList } from '@/ui/view/dataverse/component/generalMetadata/generalMetadata'
 import './pageTemplate.scss'
+import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
+import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
 
 type PageTemplateProps = {
   data: DataverseItemDetails
@@ -37,6 +39,7 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
         {data.label}
         {tags.length > 0 && <Tags tags={tags} />}
         <GeneralMetadataList metadata={generalMetadata} />
+        {isDataSpace(data) && <GovernanceDescription description={data.governance.description} />}
       </div>
     </div>
   )


### PR DESCRIPTION
This PR adds the governance description card to the data space details page, with correct layout as per:
- #72

<details>
<summary>1920px</summary>

![Capture d’écran 2023-03-31 à 02 19 29](https://user-images.githubusercontent.com/75730728/228992621-4f2ee3fd-ba75-4ce0-a992-2a2d0702227c.png)

</details>

<details>
<summary>1440px</summary>

![Capture d’écran 2023-03-31 à 02 19 04](https://user-images.githubusercontent.com/75730728/228992622-cd56b577-d891-44e2-9d03-41032e2b9a83.png)

</details>

<details>
<summary>768px</summary>

![Capture d’écran 2023-03-31 à 02 18 47](https://user-images.githubusercontent.com/75730728/228992624-1e979e7c-e11d-48d5-bac9-a1124df351fc.png)

</details>

<details>
<summary>375px</summary>
<details>
<summary>dark</summary>

![Capture d’écran 2023-03-31 à 02 18 34](https://user-images.githubusercontent.com/75730728/228992629-db36ead5-70d7-4b7b-9083-0f025313faec.png)

</details>

<details>
<summary>light</summary>

![Capture d’écran 2023-03-31 à 02 18 28](https://user-images.githubusercontent.com/75730728/228992633-4dc36cb6-1cb7-4d9b-986b-2d8d5508aa4b.png)

</details>
</details>

This PR depends on 
- #148 