### PR TITLE
Feat: add previous page button

### DIFF
--- a/src/ui/component/tag/tag.scss
+++ b/src/ui/component/tag/tag.scss
@@ -1,26 +1,27 @@
 @import '@/ui/style/fonts.scss';
 @import '@/ui/style/theme.scss';
 
-$colors: (
-  'primary-color': 'background-primary-variant',
-  'primary-color-variant-3': 'background-primary-variant-3',
-  'primary-color-variant-4': 'background-primary-variant-4'
-);
-
 .okp4-dataverse-portal-tag-main {
   @include with-theme {
     @include noto-sans(700);
-    border-radius: 0 20px;
-    padding: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: themed(primary-color-variant-3);
     font-size: 14px;
-    line-height: 24px;
-    letter-spacing: 2px;
+    min-height: 34px;
+    padding: 0 8px;
+    line-height: 18px;
+    background: rgba(themed(primary-color-variant-3), 0.12);
+    border-radius: 6px;
 
-    @each $color-key, $color-value in $colors {
-      &.#{$color-key} {
-        color: themed($color-key);
-        background-color: themed($color-value);
-      }
+    .okp4-dataverse-portal-tag-name {
+      display: box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: 240px;
     }
   }
 }

--- a/src/ui/component/tag/tag.tsx
+++ b/src/ui/component/tag/tag.tsx
@@ -1,13 +1,12 @@
-import classNames from 'classnames'
+import type { FC } from 'react'
 import './tag.scss'
 
-export type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
-
 type TagProps = {
-  label: string
-  colorVariant?: ColorVariant
+  tagName: string
 }
 
-export const Tag = ({ label, colorVariant = 'primary-color-variant-3' }: TagProps): JSX.Element => (
-  <div className={classNames('okp4-dataverse-portal-tag-main', colorVariant)}>{label}</div>
+export const Tag: FC<TagProps> = ({ tagName }) => (
+  <div className="okp4-dataverse-portal-tag-main">
+    <div className='okp4-dataverse-portal-tag-name'>{tagName}</div>
+  </div>
 )

--- a/src/ui/page/dataverse/dataset/dataset.tsx
+++ b/src/ui/page/dataverse/dataset/dataset.tsx
@@ -4,6 +4,7 @@ import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
 
 const Dataset = (): JSX.Element => {
   const { id } = useParams<string>()
@@ -15,7 +16,8 @@ const Dataset = (): JSX.Element => {
 
   return match(
     () => <p>Dataset not found</p>,
-    (dataset: DataverseItemDetails) => <p>{dataset.label}</p>
+    (dataset: DataverseItemDetails) =>
+      <PageTemplate data={dataset} />
   )(dataset)
 }
 

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -4,6 +4,7 @@ import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
 
 const Dataspace = (): JSX.Element => {
   const { id } = useParams<string>()
@@ -15,7 +16,8 @@ const Dataspace = (): JSX.Element => {
 
   return match(
     () => <p>Dataspace not found</p>,
-    (dataspace: DataverseItemDetails) => <p>{dataspace.label}</p>
+    (dataspace: DataverseItemDetails) =>
+      <PageTemplate data={dataspace} />
   )(dataspace)
 }
 

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -53,21 +53,24 @@ const dataverseItems: DataverseItemDetails[] = [
     type: 'dataspace',
     label: 'Rhizome',
     description:
-      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.'
+      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.',
+    tags: ['Agriculture', 'Open data', 'Dataviz']
   },
   {
     id: '2',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 DEPARTMENT',
     description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '3',
     type: 'service',
     label: 'Data Connector',
     description:
-      'This service allows you to inject data files into OpenSearch so that you can consume the knowledge created through visualization.'
+      'This service allows you to inject data files into OpenSearch so that you can consume the knowledge created through visualization.',
+    tags: ['Regroupement', 'Traitement de données']
   },
   {
     type: 'dataset',
@@ -75,76 +78,87 @@ const dataverseItems: DataverseItemDetails[] = [
     label:
       'Crop and crop group reference table of the Graphic Parcel Register (Registre Parcellaire Graphique)',
     description:
-      'Table specific to the distribution of the Graphic Parcel Register (Registre Parcellaire Graphique)): The notion of crop group in this table does not correspond to the notion of crop group of the CAP regulation nor to that of the ISIS reference systems. In this table, each crop code is explained by a label and linked to a crop group code and its label.'
+      'Table specific to the distribution of the Graphic Parcel Register (Registre Parcellaire Graphique)): The notion of crop group in this table does not correspond to the notion of crop group of the CAP regulation nor to that of the ISIS reference systems. In this table, each crop code is explained by a label and linked to a crop group code and its label.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '5',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 REGION',
     description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '6',
     type: 'service',
     label: 'Data Refactor',
     description:
-      'The Data Refactor tool allows you to edit and modify a data set in order to standardize it.'
+      'The Data Refactor tool allows you to edit and modify a data set in order to standardize it.',
+    tags: ['Regroupement', 'Traitement de données']
   },
   {
     id: '7',
     type: 'dataset',
     label: 'FRANCE : REGION - DEPARTMENT - CITY',
     description:
-      'This dataset is obtained by joining 3 ADMIN EXPRESS datasets containing the different layers of the French territory: Region, Department and City.'
+      'This dataset is obtained by joining 3 ADMIN EXPRESS datasets containing the different layers of the French territory: Region, Department and City.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '8',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2020 DEPARTMENT',
     description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '9',
     type: 'service',
     label: 'Data Join Tabular',
     description:
-      'The Data Join Tabular tool allows you to join two datasets containing common values to provide new information.'
+      'The Data Join Tabular tool allows you to join two datasets containing common values to provide new information.',
+    tags: ['Regroupement', 'Traitement de données']
   },
   {
     id: '10',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2022 CITY',
     description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '11',
     type: 'dataset',
     label: 'RPG FRANCE 2020',
     description:
-      'The graphical parcel register is a geographic database used as a reference for the instruction of Common Agricultural Policy (CAP) subsidies. The anonymized version distributed here as part of the public service for making reference data available contains the graphic data of parcels (since 2015) with their main crop. These data are produced by the Agency of Services and Payment (ASP) since 2007'
+      'The graphical parcel register is a geographic database used as a reference for the instruction of Common Agricultural Policy (CAP) subsidies. The anonymized version distributed here as part of the public service for making reference data available contains the graphic data of parcels (since 2015) with their main crop. These data are produced by the Agency of Services and Payment (ASP) since 2007',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '12',
     type: 'service',
     label: 'Data Grouping',
-    description: 'The Data Grouping tool allows you to organize identical data into groups.'
+    description: 'The Data Grouping tool allows you to organize identical data into groups.',
+    tags: ['Regroupement', 'Traitement de données']
   },
   {
     id: '13',
     type: 'dataset',
     label: 'AGRESTE 2020',
     description:
-      'Annual agricultural statistics, consisting of the areas, yields and production of the French territory.'
+      'Annual agricultural statistics, consisting of the areas, yields and production of the French territory.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '14',
     type: 'dataset',
     label: 'RPG AGRESTE 2020',
     description:
-      'Data set resulting from the join between RPG and AGRESTE data. Obtained through a sequence of data processing using the OKP4 protocol.'
+      'Data set resulting from the join between RPG and AGRESTE data. Obtained through a sequence of data processing using the OKP4 protocol.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   { id: '15', type: 'service', label: 'Storage', description: 'Data storage service' },
   {
@@ -152,34 +166,39 @@ const dataverseItems: DataverseItemDetails[] = [
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2020 REGION',
     description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '17',
     type: 'dataset',
     label: 'Reference table of NAF Rev2 codes',
     description:
-      'The French Nomenclature of Activities (NAF) is a nomenclature of productive economic activities, mainly developed to facilitate the organization of economic and social information.'
+      'The French Nomenclature of Activities (NAF) is a nomenclature of productive economic activities, mainly developed to facilitate the organization of economic and social information.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '18',
     type: 'service',
     label: 'Data Join Geospatial',
-    description: 'The Data Join Geospatial tool allows to join two georeferenced datasets.'
+    description: 'The Data Join Geospatial tool allows to join two georeferenced datasets.',
+    tags: ['Regroupement', 'Traitement de données']
   },
   {
     id: '19',
     type: 'dataset',
     label: 'BASE SIRENE - NAF',
     description:
-      'This dataset is obtained using the join between the SIRENE database and the NAF code reference table to obtain information on the activity of establishments.'
+      'This dataset is obtained using the join between the SIRENE database and the NAF code reference table to obtain information on the activity of establishments.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   },
   {
     id: '20',
     type: 'dataset',
     label: 'SIRENE database - agriculture, forestry and fishing',
     description:
-      'This dataset refers to all the agricultural, forestry and fishing companies in France in activity. Obtained through a sequence of data processing using the OKP4 protocol.'
+      'This dataset refers to all the agricultural, forestry and fishing companies in France in activity. Obtained through a sequence of data processing using the OKP4 protocol.',
+    tags: ['Agriculture', 'France', 'Open data', 'Rendement', 'Departemnet', 'Superficie', 'RPG']
   }
 ]
 

--- a/src/ui/page/dataverse/service/service.tsx
+++ b/src/ui/page/dataverse/service/service.tsx
@@ -4,6 +4,7 @@ import type { Option } from 'fp-ts/Option'
 import { match, none } from 'fp-ts/Option'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
 
 const Service = (): JSX.Element => {
   const { id } = useParams<string>()
@@ -15,7 +16,8 @@ const Service = (): JSX.Element => {
 
   return match(
     () => <p>Service not found</p>,
-    (service: DataverseItemDetails) => <p>{service.label}</p>
+    (service: DataverseItemDetails) =>
+      <PageTemplate data={service} />
   )(service)
 }
 

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.scss
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.scss
@@ -2,7 +2,13 @@
 @import '@/ui/style/mixins.scss';
 @import '@/ui/style/theme.scss';
 
-.okp4-dataverse-portal-dataverse-item-card-main {
+$colors: (
+  'primary-color': 'background-primary-variant',
+  'primary-color-variant-3': 'background-primary-variant-3',
+  'primary-color-variant-4': 'background-primary-variant-4'
+);
+
+.okp4-dataverse-portal-dataverse-card-main {
   @include with-theme {
     width: 100%;
     height: 100%;
@@ -11,7 +17,8 @@
     position: relative;
     color: themed('text');
 
-    .okp4-dataverse-portal-tag-main {
+    .okp4-dataverse-portal-dataverse-item-type {
+      @include noto-sans(700);
       position: absolute;
       min-width: 137px;
       max-height: 40px;
@@ -25,6 +32,19 @@
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
+      border-radius: 0 20px;
+      padding: 8px;
+      font-size: 14px;
+      line-height: 24px;
+      letter-spacing: 2px;
+
+      @each $color-key,
+        $color-value in $colors {
+        &.#{$color-key} {
+          color: themed($color-key);
+          background-color: themed($color-value);
+        }
+      }
     }
 
     .okp4-dataverse-portal-dataverse-item-card-content {

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -1,13 +1,12 @@
 import type { FC } from 'react'
 import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { Card } from '@/ui/component/card/card'
 import { Button } from '@/ui/component/button/button'
-import { Tag } from '@/ui/component/tag/tag'
-import type { ColorVariant } from '@/ui/component/tag/tag'
 import './dataverseItemCard.scss'
+import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
 
 type DataverseItem = 'dataspace' | 'dataset' | 'service'
 
@@ -16,13 +15,16 @@ export type DataverseItemCardProps = {
   type: DataverseItem
   label: string
   description: string
+  tags?: Array<string>
 }
 
 export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label, description }) => {
   const navigate = useNavigate()
   const { t } = useTranslation('common')
 
-  const renderTagColor = useCallback((type: DataverseItem): ColorVariant => {
+  type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
+
+  const renderItemTypeColor = useCallback((type: DataverseItem): ColorVariant => {
     switch (type) {
       case 'service':
         return 'primary-color'
@@ -45,8 +47,8 @@ ${description}`,
 
   return (
     <Card>
-      <div className="okp4-dataverse-portal-dataverse-item-card-main">
-        <Tag colorVariant={renderTagColor(type)} label={t(`resources.${type}`)} />
+      <div className="okp4-dataverse-portal-dataverse-card-main">
+        <div className={classNames('okp4-dataverse-portal-dataverse-item-type', renderItemTypeColor(type))}>{t(`resources.${type}`)}</div>
         <div className="okp4-dataverse-portal-dataverse-item-card-content">
           <div className="okp4-dataverse-portal-dataverse-description">
             <ReactMarkdown>{renderItemContent(label, description)}</ReactMarkdown>

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -1,0 +1,12 @@
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-dataverse-component-page-template-main {
+  @include twelve-column-layout;
+
+  .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
+    @include bi-column-item('left');
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+}

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -1,0 +1,18 @@
+import type { FC } from 'react'
+import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import Tags from '@/ui/view/dataverse/component/tags/tags'
+import './pageTemplate.scss'
+
+type PageTemplateProps = {
+  data: DataverseItemDetails
+}
+
+const PageTemplate: FC<PageTemplateProps> = ({ data }): JSX.Element => (
+  <div className='okp4-dataverse-portal-dataverse-component-page-template-main' >
+    <div className='okp4-dataverse-portal-dataverse-page-template-left-side-wrapper'>
+      {data.tags && <Tags tags={data.tags} />}
+    </div>
+  </div>
+)
+
+export default PageTemplate

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import Tags from '@/ui/view/dataverse/component/tags/tags'
+import { NavToPrevious } from '@/ui/view/navToPrevious'
 import './pageTemplate.scss'
 
 type PageTemplateProps = {
@@ -8,8 +9,9 @@ type PageTemplateProps = {
 }
 
 const PageTemplate: FC<PageTemplateProps> = ({ data }): JSX.Element => (
-  <div className='okp4-dataverse-portal-dataverse-component-page-template-main' >
-    <div className='okp4-dataverse-portal-dataverse-page-template-left-side-wrapper'>
+  <div className="okp4-dataverse-portal-dataverse-component-page-template-main">
+    <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
+      <NavToPrevious />
       {data.tags && <Tags tags={data.tags} />}
     </div>
   </div>

--- a/src/ui/view/dataverse/component/tags/tags.scss
+++ b/src/ui/view/dataverse/component/tags/tags.scss
@@ -1,0 +1,5 @@
+.okp4-dataverse-portal-dataverse-component-description-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/src/ui/view/dataverse/component/tags/tags.tsx
+++ b/src/ui/view/dataverse/component/tags/tags.tsx
@@ -1,0 +1,17 @@
+import type { FC } from 'react'
+import { Tag } from '@/ui/component/tag/tag'
+import './tags.scss'
+
+type TagsProps = {
+  tags?: Array<string>
+}
+
+const Tags: FC<TagsProps> = ({ tags }): JSX.Element => (
+  <div className='okp4-dataverse-portal-dataverse-component-description-tags'>
+    {tags?.map((tag: string) => {
+      return <Tag key={`dataset-tags-${tag}`} tagName={tag} ></Tag>
+    })}
+  </div>
+)
+
+export default Tags

--- a/src/ui/view/navToPrevious.scss
+++ b/src/ui/view/navToPrevious.scss
@@ -1,0 +1,15 @@
+@import '@/ui/style/theme.scss';
+
+.okp4-dataverse-portal-previous-button-main {
+  @include with-theme {
+    width: fit-content;
+    padding: 10px 7px;
+    cursor: pointer;
+
+    svg {
+      path {
+        fill: themed('text');
+      }
+    }
+  }
+}

--- a/src/ui/view/navToPrevious.tsx
+++ b/src/ui/view/navToPrevious.tsx
@@ -1,0 +1,15 @@
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Icon } from '../component/icon/icon'
+import './navToPrevious.scss'
+
+export const NavToPrevious = (): JSX.Element => {
+  const navigate = useNavigate()
+  const handlePreviousPage = useCallback((): void => navigate(-1), [navigate])
+
+  return (
+    <div className="okp4-dataverse-portal-previous-button-main" onClick={handlePreviousPage}>
+      <Icon name="arrow-left" />
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds a previous button which is now displayed on `Dataset`, `Dataspace` and also `Service` page.
This button allows for now to navigate to `Dataverse` page (even if we come from `Home` page).
It completes this [issue](https://github.com/okp4/dataverse-portal/issues/97).
