### PR TITLE
Feat: add max width to portal page to avoid stretched elements

### DIFF
--- a/src/ui/main.scss
+++ b/src/ui/main.scss
@@ -114,6 +114,7 @@ p {
 
     .okp4-dataverse-portal-page-wrapper {
       @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: auto);
+      max-width: 2000px;
       overflow-y: auto;
       padding-bottom: 25px;
 


### PR DESCRIPTION
This PR implements this [issue](https://github.com/okp4/dataverse-portal/issues/151), which improves the app pages display on large screens.
It prevents page elements to stretch by adding a `max-width` on the portal pages wrapper.
You can find some screenshots on the issue.