### PR TITLE
Feat: add back to dataverse button on dataverse items pages

### DIFF
--- a/src/ui/i18n/translations/common_de.json
+++ b/src/ui/i18n/translations/common_de.json
@@ -15,5 +15,6 @@
     "details": "Siehe Details",
     "accessGovernance": "Auf Governance zugreifen"
   },
-  "filters": "Filter"
+  "filters": "Filter",
+  "dataverse": "Dataverse"
 }

--- a/src/ui/i18n/translations/common_en.json
+++ b/src/ui/i18n/translations/common_en.json
@@ -15,5 +15,6 @@
     "details": "See Details",
     "accessGovernance": "Access governance"
   },
-  "filters": "Filters"
+  "filters": "Filters",
+  "dataverse": "Dataverse"
 }

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -15,5 +15,6 @@
     "details": "Voir Détails",
     "accessGovernance": "Accéder à la gouvernance"
   },
-  "filters": "Filtres"
+  "filters": "Filtres",
+  "dataverse": "Dataverse"
 }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -1,4 +1,5 @@
 @import '@/ui/style/mixins.scss';
+@import '@/ui/style/theme.scss';
 
 .okp4-dataverse-portal-dataverse-component-page-template-main {
   @include twelve-column-layout;
@@ -8,5 +9,19 @@
     display: flex;
     flex-direction: column;
     row-gap: 40px;
+
+    .okp4-dataverse-portal-dataverse-button {
+      @include with-theme {
+        width: fit-content;
+        padding: 10px 7px;
+        cursor: pointer;
+
+        svg {
+          path {
+            fill: themed('text');
+          }
+        }
+      }
+    }
   }
 }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -1,5 +1,6 @@
-@import '@/ui/style/mixins.scss';
 @import '@/ui/style/theme.scss';
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/mixins.scss';
 
 .okp4-dataverse-portal-dataverse-component-page-template-main {
   @include twelve-column-layout;
@@ -10,16 +11,33 @@
     flex-direction: column;
     row-gap: 40px;
 
-    .okp4-dataverse-portal-dataverse-button {
+    .okp4-dataverse-portal-dataverse-back {
       @include with-theme {
-        width: fit-content;
-        padding: 10px 7px;
-        cursor: pointer;
+        display: flex;
+        align-items: center;
 
-        svg {
-          path {
-            fill: themed('text');
+        .okp4-dataverse-portal-dataverse-back-button {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          background: none;
+          border: 0;
+          width: fit-content;
+          padding: 10px 7px;
+          cursor: pointer;
+  
+          svg {
+            path {
+              fill: themed('text');
+            }
           }
+        }
+        
+        .okp4-dataverse-portal-dataverse-back-text {
+          @include noto-sans(700);
+          font-size: 14px;
+          line-height: 22px;
+          color: themed('text');
         }
       }
     }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -4,42 +4,43 @@
 
 .okp4-dataverse-portal-dataverse-component-page-template-main {
   @include twelve-column-layout;
+  row-gap: 19px;
+
+  .okp4-dataverse-portal-dataverse-back {
+    @include with-theme {
+      display: flex;
+      align-items: center;
+
+      .okp4-dataverse-portal-dataverse-back-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: none;
+        border: 0;
+        width: fit-content;
+        padding: 10px 7px;
+        cursor: pointer;
+
+        svg {
+          path {
+            fill: themed('text');
+          }
+        }
+      }
+      
+      .okp4-dataverse-portal-dataverse-back-text {
+        @include noto-sans(700);
+        font-size: 14px;
+        line-height: 22px;
+        color: themed('text');
+      }
+    }
+  }
 
   .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
     @include bi-column-item('left');
     display: flex;
     flex-direction: column;
     row-gap: 40px;
-
-    .okp4-dataverse-portal-dataverse-back {
-      @include with-theme {
-        display: flex;
-        align-items: center;
-
-        .okp4-dataverse-portal-dataverse-back-button {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          background: none;
-          border: 0;
-          width: fit-content;
-          padding: 10px 7px;
-          cursor: pointer;
-  
-          svg {
-            path {
-              fill: themed('text');
-            }
-          }
-        }
-        
-        .okp4-dataverse-portal-dataverse-back-text {
-          @include noto-sans(700);
-          font-size: 14px;
-          line-height: 22px;
-          color: themed('text');
-        }
-      }
-    }
   }
 }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -1,4 +1,6 @@
+import { useCallback } from 'react'
 import type { FC } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { pipe } from 'fp-ts/lib/function'
 import * as A from 'fp-ts/Array'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
@@ -8,6 +10,7 @@ import { GeneralMetadataList } from '@/ui/view/dataverse/component/generalMetada
 import './pageTemplate.scss'
 import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
 import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
+import { Icon } from '@/ui/component/icon/icon'
 
 type PageTemplateProps = {
   data: DataverseItemDetails
@@ -25,6 +28,8 @@ const isGeneralMetadata = (
   metadata.property !== 'tags'
 
 const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element => {
+  const navigate = useNavigate()
+  const backToDataverse = useCallback((): void => navigate('/dataverse'), [navigate])
   const tags = pipe(
     metadata,
     A.filter(isTagsMetadata),
@@ -36,6 +41,9 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
   return (
     <div className="okp4-dataverse-portal-dataverse-component-page-template-main">
       <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
+        <div className="okp4-dataverse-portal-dataverse-button" onClick={backToDataverse}>
+          <Icon name="arrow-left" />
+        </div>
         {data.label}
         {tags.length > 0 && <Tags tags={tags} />}
         <GeneralMetadataList metadata={generalMetadata} />

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -41,8 +41,11 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
   return (
     <div className="okp4-dataverse-portal-dataverse-component-page-template-main">
       <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
-        <div className="okp4-dataverse-portal-dataverse-button" onClick={backToDataverse}>
-          <Icon name="arrow-left" />
+        <div className="okp4-dataverse-portal-dataverse-back">
+          <button className="okp4-dataverse-portal-dataverse-back-button" onClick={backToDataverse}>
+            <Icon name="arrow-left" />
+          </button>
+          <span className="okp4-dataverse-portal-dataverse-back-text">Dataverse</span>
         </div>
         {data.label}
         {tags.length > 0 && <Tags tags={tags} />}

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -11,6 +11,7 @@ import './pageTemplate.scss'
 import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
 import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
 import { Icon } from '@/ui/component/icon/icon'
+import { useTranslation } from 'react-i18next'
 
 type PageTemplateProps = {
   data: DataverseItemDetails
@@ -28,14 +29,15 @@ const isGeneralMetadata = (
   metadata.property !== 'tags'
 
 const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element => {
+  const { t } = useTranslation('common')
   const navigate = useNavigate()
   const backToDataverse = useCallback((): void => navigate('/dataverse'), [navigate])
+
   const tags = pipe(
     metadata,
     A.filter(isTagsMetadata),
     A.chain(metadata => metadata.value)
   )
-
   const generalMetadata = pipe(metadata, A.filter(isGeneralMetadata))
 
   return (
@@ -45,7 +47,7 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
           <button className="okp4-dataverse-portal-dataverse-back-button" onClick={backToDataverse}>
             <Icon name="arrow-left" />
           </button>
-          <span className="okp4-dataverse-portal-dataverse-back-text">Dataverse</span>
+          <span className="okp4-dataverse-portal-dataverse-back-text">{t('dataverse')}</span>
         </div>
         {data.label}
         {tags.length > 0 && <Tags tags={tags} />}

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -42,13 +42,13 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
 
   return (
     <div className="okp4-dataverse-portal-dataverse-component-page-template-main">
+      <div className="okp4-dataverse-portal-dataverse-back">
+        <button className="okp4-dataverse-portal-dataverse-back-button" onClick={backToDataverse}>
+          <Icon name="arrow-left" />
+        </button>
+        <span className="okp4-dataverse-portal-dataverse-back-text">{t('dataverse')}</span>
+      </div>
       <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
-        <div className="okp4-dataverse-portal-dataverse-back">
-          <button className="okp4-dataverse-portal-dataverse-back-button" onClick={backToDataverse}>
-            <Icon name="arrow-left" />
-          </button>
-          <span className="okp4-dataverse-portal-dataverse-back-text">{t('dataverse')}</span>
-        </div>
         {data.label}
         {tags.length > 0 && <Tags tags={tags} />}
         <GeneralMetadataList metadata={generalMetadata} />


### PR DESCRIPTION
This PR adds a previous button which is now displayed on `Dataset`, `Dataspace` and also `Service` page.
This button allows for now to navigate to `Dataverse` page (even if we come from `Home` page).
It completes this [issue](https://github.com/okp4/dataverse-portal/issues/97) and  [this one](https://github.com/okp4/dataverse-portal/issues/168).

![image](https://user-images.githubusercontent.com/8344874/230120617-27c1adec-d91c-4095-a459-256c5c094389.png)

![image](https://user-images.githubusercontent.com/8344874/230120767-0b8f1085-44db-4901-a5dc-247486806f76.png)
