### PR TITLE
Feat/add data space resource cards

### DIFF
--- a/src/ui/i18n/translations/common_de.json
+++ b/src/ui/i18n/translations/common_de.json
@@ -8,7 +8,8 @@
     "dataspaces": "Datenräume",
     "datasets": "Datensätze",
     "services": "Dienstleistungen",
-    "governance": "Führung"
+    "governance": "Führung",
+    "lastUpdate": "Letzte Aktualisierung"
   },
   "actions": {
     "explore": "Erkunden Sie",

--- a/src/ui/i18n/translations/common_en.json
+++ b/src/ui/i18n/translations/common_en.json
@@ -8,7 +8,8 @@
     "dataspaces": "Data Spaces",
     "datasets": "Datasets",
     "services": "Services",
-    "governance": "Governance"
+    "governance": "Governance",
+    "lastUpdate": "Last update"
   },
   "actions": {
     "explore": "Explore",

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -6,9 +6,10 @@
     "dataset": "Données",
     "service": "Service",
     "dataspaces": "Data Spaces",
-    "datasets": "Données",
+    "datasets": "Jeux de données",
     "services": "Services",
-    "governance": "Gouvernance"
+    "governance": "Gouvernance",
+    "lastUpdate": "Dernière mise à jour"
   },
   "actions": {
     "explore": "Explorer",

--- a/src/ui/page/dataverse/dataverse.scss
+++ b/src/ui/page/dataverse/dataverse.scss
@@ -33,15 +33,7 @@
 
         h1 {
           @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);
-          @include norse-font(700);
-          width: fit-content;
-          line-height: 61px;
-          letter-spacing: 4px;
-          font-size: 24px;
-          background: themed('gradient');
-          /* stylelint-disable-next-line property-no-vendor-prefix */
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
+          @include norse-gradient-header($line-height: 61px);
         }
 
         h2 {
@@ -151,15 +143,7 @@
 
       h1 {
         @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
-        @include norse-font(700);
-        width: fit-content;
-        line-height: 61px;
-        letter-spacing: 4px;
-        font-size: 24px;
-        background: themed('gradient');
-        /* stylelint-disable-next-line property-no-vendor-prefix */
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
+        @include norse-gradient-header($line-height: 61px);
 
         @include use-breakpoints(('mobile', 'tablet')) {
           @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -12,8 +12,9 @@ import { Icon } from '@/ui/component/icon/icon'
 import type { IconName } from '@/ui/component/icon/icon'
 import './dataverse.scss'
 
+type DataverseItemType = 'service' | 'dataspace' | 'dataset'
 type FilterLabel = 'dataspaces' | 'datasets' | 'services' | 'all'
-type FilterValue = 'dataspace' | 'dataset' | 'service' | 'all'
+type FilterValue = DataverseItemType | 'all'
 
 type DataverseItem = {
   id: string
@@ -29,7 +30,13 @@ type Governance = {
   description: InternationalizedDescription
 }
 
-type Typed<T extends 'service' | 'dataspace' | 'dataset'> = { type: T }
+type Typed<T extends DataverseItemType> = { type: T }
+
+type DataSpaceResource = {
+  type: Exclude<DataverseItemType, 'dataspace'>
+  amount: number
+  lastUpdated: string
+}
 
 export type Service = DataverseItem & Typed<'service'>
 
@@ -38,6 +45,7 @@ export type Dataset = DataverseItem & Typed<'dataset'>
 export type DataSpace = DataverseItem &
   Typed<'dataspace'> & {
     governance: Governance
+    resources: DataSpaceResource[]
   }
 
 export type DataverseItemDetails = DataSpace | Dataset | Service
@@ -84,7 +92,19 @@ const dataverseItems: DataverseItemDetails[] = [
         fr: "Ce premier Data Space a une gouvernance centralisée : seul OKP4 peut modifier les règles. Dans cette première version, seul OKP4 peut enregistrer des données et des services. Toutefois, n'importe quel wallet est autorisé à télécharger les données.",
         de: 'Dieser erste Data Space hat eine zentralisierte Governance: Nur OKP4 kann die Regeln ändern. In dieser ersten Version kann nur OKP4 Daten und Dienste speichern. Allerdings ist es jeder Wallet erlaubt, Daten hochzuladen.'
       }
-    }
+    },
+    resources: [
+      {
+        type: 'dataset',
+        amount: 20,
+        lastUpdated: '2023-03-28T00:00:00+00:00'
+      },
+      {
+        type: 'service',
+        amount: 7,
+        lastUpdated: '2023-03-31T00:00:00+00:00'
+      }
+    ]
   },
   {
     id: '2',
@@ -224,7 +244,19 @@ const dataverseItems: DataverseItemDetails[] = [
         fr: "DS4I est un Data Space privé où les ressources ne sont accessibles que pour un groupe d'adresses de wallets contenues dans une Whitelist dédiée. Seul OKP4 a le droit de modifier cette whitelist.",
         de: 'DS4I ist ein privater Data Space, in dem die Ressourcen nur für eine Gruppe zugänglich sind. Adressen von Wallets, die in einer dedizierten Whitelist enthalten sind. Nur OKP4 hat das Recht, diese Whitelist zu ändern.'
       }
-    }
+    },
+    resources: [
+      {
+        type: 'dataset',
+        amount: 1,
+        lastUpdated: '2023-03-25T00:00:00+00:00'
+      },
+      {
+        type: 'service',
+        amount: 1,
+        lastUpdated: '2023-04-02T00:00:00+00:00'
+      }
+    ]
   }
 ]
 

--- a/src/ui/page/home/home.scss
+++ b/src/ui/page/home/home.scss
@@ -16,15 +16,7 @@
 
       h1 {
         @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);
-        @include norse-font(700);
-        width: fit-content;
-        line-height: 36px;
-        letter-spacing: 4px;
-        font-size: 24px;
-        background: themed('gradient');
-        /* stylelint-disable-next-line property-no-vendor-prefix */
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
+        @include norse-gradient-header;
 
         @include use-breakpoints(('tablet', 'mobile')) {
           justify-self: center;

--- a/src/ui/style/mixins.scss
+++ b/src/ui/style/mixins.scss
@@ -48,8 +48,6 @@
 }
 
 @mixin twelve-column-layout {
-  row-gap: 40px;
-
   @include use-breakpoints(('mobile')) {
     @include grid-container($colsNb: 6, $gutter: 16px);
   }

--- a/src/ui/style/mixins.scss
+++ b/src/ui/style/mixins.scss
@@ -89,3 +89,15 @@
     }
   }
 }
+
+@mixin norse-gradient-header($line-height: 36px) {
+  @include norse-font(700);
+  width: fit-content;
+  line-height: $line-height;
+  letter-spacing: 4px;
+  font-size: 24px;
+  background: themed('gradient');
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/src/ui/view/dataverse/component/dataverseItemStatCard/dataversItemStatCard.scss
+++ b/src/ui/view/dataverse/component/dataverseItemStatCard/dataversItemStatCard.scss
@@ -1,0 +1,57 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-main {
+  @include with-theme {
+    justify-content: space-between;
+    min-height: 110px;
+    padding: 0 40px;
+    column-gap: 10px;
+
+    @include use-breakpoints(('mobile')) {
+      padding: 0 20px;
+    }
+
+    .okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-description {
+      display: flex;
+      column-gap: 30px;
+
+      @include use-breakpoints(('mobile')) {
+        column-gap: 9px;
+      }
+
+      .okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-icon-wrapper {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 46px;
+        width: 46px;
+        border-radius: 6px;
+        background-color: rgba(themed('background-variant-1'), 0.06);
+      }
+
+      .okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-type {
+        @include noto-sans(700);
+        line-height: 28px;
+        color: themed('text');
+      }
+
+      .okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-updated {
+        @include noto-sans(400);
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 5px;
+        font-size: 14px;
+        line-height: 20px;
+        color: rgba(themed('text'), 0.4);
+      }
+    }
+
+    .okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-stat {
+      @include noto-sans(700);
+      font-size: 24px;
+      color: themed('text');
+    }
+  }
+}

--- a/src/ui/view/dataverse/component/dataverseItemStatCard/dataverseItemStatCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemStatCard/dataverseItemStatCard.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card } from '@/ui/component/card/card'
+import { Icon } from '@/ui/component/icon/icon'
+import { useAppStore } from '@/ui/store/appStore'
+import { activeLanguageWithDefault } from '@/ui/languages/languages'
+import './dataversItemStatCard.scss'
+
+type DataverseItemStatCardProps = {
+  type: 'dataset' | 'service'
+  amount: number
+  lastUpdated: string
+}
+
+export const DataverseItemStatCard = ({
+  type,
+  amount,
+  lastUpdated
+}: DataverseItemStatCardProps): JSX.Element => {
+  const { t } = useTranslation('common')
+  const theme = useAppStore(store => store.theme)
+  const currentLng = activeLanguageWithDefault().lng
+
+  const localisedLastUpdate = useMemo(() => {
+    const dateTimeFormat = new Intl.DateTimeFormat(currentLng, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    })
+    const lastUpdateDate = new Date(lastUpdated)
+    return dateTimeFormat.format(lastUpdateDate).replaceAll(/[.,]/g, '')
+  }, [lastUpdated, currentLng])
+
+  return (
+    <Card mainClassName="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-main">
+      <>
+        <div className="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-description">
+          <div className="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-icon-wrapper">
+            <Icon name={`${type}-folder-${theme}`} />
+          </div>
+          <div>
+            <p className="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-type">
+              {t(`resources.${type === 'dataset' ? 'datasets' : 'services'}`)}
+            </p>
+            <div className="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-updated">
+              <p>{t('resources.lastUpdate')}</p>
+              <p>{localisedLastUpdate}</p>
+            </div>
+          </div>
+        </div>
+        <p className="okp4-dataverse-portal-data-space-details-dataverse-item-stat-card-stat">
+          {amount}
+        </p>
+      </>
+    </Card>
+  )
+}

--- a/src/ui/view/dataverse/component/pageTemplate/i18n/index.ts
+++ b/src/ui/view/dataverse/component/pageTemplate/i18n/index.ts
@@ -1,0 +1,13 @@
+import pageTemplate_en from './pageTemplate_en.json'
+import pageTemplate_fr from './pageTemplate_fr.json'
+import pageTemplate_de from './pageTemplate_de.json'
+import type { I18nResource } from '@/ui/i18n/utils'
+import { loadTranslations } from '@/ui/i18n/utils'
+
+const i18nTranslations: I18nResource[] = [
+  { lng: 'en', namespace: 'pageTemplate', resource: pageTemplate_en },
+  { lng: 'fr', namespace: 'pageTemplate', resource: pageTemplate_fr },
+  { lng: 'de', namespace: 'pageTemplate', resource: pageTemplate_de }
+]
+
+loadTranslations(i18nTranslations)

--- a/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_de.json
+++ b/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_de.json
@@ -1,0 +1,3 @@
+{
+  "inDataspace": "In diesem Data Space"
+}

--- a/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_en.json
+++ b/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_en.json
@@ -1,0 +1,3 @@
+{
+  "inDataspace": "In this Data Space"
+}

--- a/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_fr.json
+++ b/src/ui/view/dataverse/component/pageTemplate/i18n/pageTemplate_fr.json
@@ -1,0 +1,3 @@
+{
+  "inDataspace": "Dans ce Data Space"
+}

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -3,14 +3,15 @@
 @import '@/ui/style/mixins.scss';
 
 .okp4-dataverse-portal-dataverse-component-page-template-main {
-  @include twelve-column-layout;
-  row-gap: 19px;
-  @include use-breakpoints(('mobile')) {
-    row-gap: 13px;
-  }
+  @include with-theme {
+    @include twelve-column-layout;
+    row-gap: 19px;
 
-  .okp4-dataverse-portal-dataverse-back {
-    @include with-theme {
+    @include use-breakpoints(('mobile')) {
+      row-gap: 13px;
+    }
+
+    .okp4-dataverse-portal-dataverse-back {
       display: flex;
       align-items: center;
 
@@ -30,7 +31,7 @@
           }
         }
       }
-      
+
       .okp4-dataverse-portal-dataverse-back-text {
         @include noto-sans(700);
         font-size: 14px;
@@ -38,12 +39,34 @@
         color: themed('text');
       }
     }
-  }
 
-  .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
-    @include bi-column-item('left');
-    display: flex;
-    flex-direction: column;
-    row-gap: 40px;
+    .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
+      @include bi-column-item('left');
+      display: flex;
+      flex-direction: column;
+      row-gap: 40px;
+    }
+
+    .okp4-dataverse-portal-dataverse-page-template-right-side-wrapper {
+      @include bi-column-item($side: 'right');
+
+      h2 {
+        @include norse-gradient-header;
+        margin-bottom: 30px;
+
+        @include use-breakpoints(('mobile', 'tablet')) {
+          margin: 27px auto 30px;
+        }
+      }
+
+      .okp4-dataverse-portal-dataverse-page-template-dataverse-item-stat-cards {
+        display: grid;
+        row-gap: 22px;
+
+        @include use-breakpoints(('mobile')) {
+          row-gap: 16px;
+        }
+      }
+    }
   }
 }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -1,17 +1,19 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import type { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { pipe } from 'fp-ts/lib/function'
 import * as A from 'fp-ts/Array'
+import { useTranslation } from 'react-i18next'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import { GeneralMetadataList } from '@/ui/view/dataverse/component/generalMetadata/generalMetadata'
 import ItemOverview from '@/ui/view/dataverse/component/itemOverview/itemOverview'
-import './pageTemplate.scss'
 import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
 import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
 import { Icon } from '@/ui/component/icon/icon'
-import { useTranslation } from 'react-i18next'
+import { DataverseItemStatCard } from '@/ui/view/dataverse/component/dataverseItemStatCard/dataverseItemStatCard'
+import './pageTemplate.scss'
+import './i18n/index'
 
 type PageTemplateProps = {
   data: DataverseItemDetails
@@ -28,20 +30,18 @@ const isGeneralMetadata = (
 ): metadata is Omit<ItemGeneralMetadata, 'value'> & { value: string } =>
   metadata.property !== 'tags'
 
+const tags = (metadata: ItemGeneralMetadata[]): string[] =>
+  pipe(
+    metadata,
+    A.filter(isTagsMetadata),
+    A.chain(metadata => metadata.value)
+  )
+
 const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element => {
-  const { t } = useTranslation('common')
+  const { t } = useTranslation(['pageTemplate', 'common'])
   const navigate = useNavigate()
   const backToDataverse = useCallback((): void => navigate('/dataverse'), [navigate])
 
-  const tags = useMemo(
-    () =>
-      pipe(
-        metadata,
-        A.filter(isTagsMetadata),
-        A.chain(metadata => metadata.value)
-      ),
-    [metadata]
-  )
   const generalMetadata = pipe(metadata, A.filter(isGeneralMetadata))
 
   return (
@@ -55,12 +55,29 @@ const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }): JSX.Element =>
       <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
         <ItemOverview
           description={data.description}
-          tags={tags}
+          tags={tags(metadata)}
           title={data.label}
           type={data.type}
         />
         <GeneralMetadataList metadata={generalMetadata} />
         {isDataSpace(data) && <GovernanceDescription description={data.governance.description} />}
+      </div>
+      <div className="okp4-dataverse-portal-dataverse-page-template-right-side-wrapper">
+        {isDataSpace(data) && (
+          <>
+            <h2>{t('inDataspace')}</h2>
+            <div className="okp4-dataverse-portal-dataverse-page-template-dataverse-item-stat-cards">
+              {data.resources.map(({ type, amount, lastUpdated }) => (
+                <DataverseItemStatCard
+                  amount={amount}
+                  key={type}
+                  lastUpdated={lastUpdated}
+                  type={type}
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
This PR adds the resource cards indicating the number of datasets and services in a data space, as well as when they were last updated:
- #83 
- #84

OBS! This PR also adjusts the translation for datasets in french, which is used in the filter chips as well as refactors some header style to reduce repeating style code.

<details>
<summary>1920px</summary>

![localhost_5173_dataverse_dataspace_1](https://user-images.githubusercontent.com/75730728/230348598-25635b9c-a0d1-4010-a0ab-cd5a1107287d.png)


</details>

<details>
<summary>1440px</summary>

![localhost_5173_dataverse_dataspace_1 (1)](https://user-images.githubusercontent.com/75730728/230348571-0837d307-aebc-4778-b11b-fec88b67f713.png)


</details>

<details>
<summary>768px</summary>

![localhost_5173_dataverse_dataspace_1 (4)](https://user-images.githubusercontent.com/75730728/230348542-153106f2-66fd-42e8-9d3b-1f1ab747f2d6.png)


</details>

<details>
<summary>375px</summary>

![localhost_5173_dataverse_dataspace_1 (3)](https://user-images.githubusercontent.com/75730728/230348517-2f14695d-5874-45af-a809-5e1ab9ff04c9.png)


</details>