### PR TITLE
Feat/dataverse ontology

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
   }
 }

--- a/public/assets/env.js
+++ b/public/assets/env.js
@@ -1,10 +1,14 @@
 const APP_ENV = {
-    urls: {
-        'social:twitter': 'https://twitter.com/OKP4_Protocol',
-        'social:linkedin': 'https://www.linkedin.com/company/okp4-open-knowledge-platform-for/',
-        'social:discord': 'https://discord.com/invite/okp4',
-        'social:medium': 'https://blog.okp4.network',
-        'form:feedback': 'https://okp4.typeform.com/to/TNyFBH72',
-        'about:okp4': 'https://okp4.network',
-      }
+  urls: {
+    'social:twitter': 'https://twitter.com/OKP4_Protocol',
+    'social:linkedin': 'https://www.linkedin.com/company/okp4-open-knowledge-platform-for/',
+    'social:discord': 'https://discord.com/invite/okp4',
+    'social:medium': 'https://blog.okp4.network',
+    'form:feedback': 'https://okp4.typeform.com/to/TNyFBH72',
+    'about:okp4': 'https://okp4.network'
+  },
+  sparql: {
+    endpoint: 'https://api.okp4.space/ontology/world/sparql',
+    credentials: ''
+  }
 }

--- a/src/domain/dataverse/aggregate.ts
+++ b/src/domain/dataverse/aggregate.ts
@@ -1,0 +1,176 @@
+/* eslint-disable max-lines-per-function */
+import { pipe } from 'fp-ts/function'
+import * as E from 'fp-ts/Either'
+import type * as T from 'fp-ts/Task'
+import * as TE from 'fp-ts/TaskEither'
+import { immer } from 'zustand/middleware/immer'
+import { createStore } from 'zustand/vanilla'
+import type { DataverseDTO } from './dto'
+import type { DataverseEntity } from './entity'
+import type { DataversePort } from './port'
+
+type ByTypeQueryFilter = 'all' | 'DataSpace' | 'Dataset' | 'Service'
+
+type DataverseQueryFilters = {
+  byType: ByTypeQueryFilter
+}
+
+type DataverseQueryError = Error | null
+
+type DataverseQuery = {
+  limit: number
+  hasNext: boolean
+  isLoading: boolean
+  error: DataverseQueryError
+  filters: DataverseQueryFilters
+  language: string
+  setIsLoading: (isLoading: boolean) => void
+  setHasNext: (hasNext: boolean) => void
+  setError: (error: DataverseQueryError) => void
+  setFilters: (newFilter: DataverseQueryFilters) => void
+  setLanguage: (newLng: string) => void
+}
+
+export type DataverseAggregate = {
+  dataverse: DataverseEntity
+  query: DataverseQuery
+  addToDataverse: (newDataverse: DataverseEntity) => void
+  clearDataverse: () => void
+  loadDataverse: () => T.Task<void> | void
+}
+
+// Public contract with the controller that consumes the store
+export type DataverseStore = {
+  query: {
+    hasNext: boolean
+    isLoading: boolean
+    error: DataverseQueryError
+    filters: DataverseQueryFilters
+    setFilters: (newFilter: DataverseQueryFilters) => void
+    setLanguage: (newLng: string) => void
+  }
+  dataverse: DataverseDTO
+  loadDataverse: () => T.Task<void> | void
+}
+
+type ImmerSetReturnType = Partial<DataverseAggregate>
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const dataverseAggregate = (gateway: DataversePort) =>
+  createStore<DataverseAggregate, [['zustand/immer', never]]>(
+    immer<DataverseAggregate>((set, get) => ({
+      dataverse: [],
+      query: {
+        limit: 21,
+        hasNext: false,
+        isLoading: false,
+        error: null,
+        filters: { byType: 'all' },
+        language: 'en',
+        setIsLoading: (isLoading: boolean): void =>
+          set(
+            (state): ImmerSetReturnType => ({
+              query: { ...state.query, isLoading }
+            })
+          ),
+        setHasNext: (hasNext: boolean): void =>
+          set(
+            (state): ImmerSetReturnType => ({
+              query: { ...state.query, hasNext }
+            })
+          ),
+        setError: (error: DataverseQueryError): void =>
+          set(
+            (state): ImmerSetReturnType => ({
+              query: { ...state.query, error }
+            })
+          ),
+        setFilters: (newFilters: DataverseQueryFilters): void => {
+          const { clearDataverse } = get()
+          clearDataverse()
+          return set(
+            (state): ImmerSetReturnType => ({
+              query: { ...state.query, filters: { ...state.query.filters, ...newFilters } }
+            })
+          )
+        },
+        setLanguage: (newLng: string): void => {
+          const {
+            clearDataverse,
+            query: { setError }
+          } = get()
+          if (!newLng.length) {
+            return setError(
+              new Error(
+                `Oops.. An error occurred in <setLanguage> call.. Parameter cannot be empty: <${newLng}>..`
+              )
+            )
+          }
+          clearDataverse()
+          return set(
+            (state): ImmerSetReturnType => ({
+              query: { ...state.query, language: newLng }
+            })
+          )
+        }
+      },
+      clearDataverse: (): void =>
+        set(
+          (): ImmerSetReturnType => ({
+            dataverse: []
+          })
+        ),
+      addToDataverse: (newDataverse: DataverseEntity): void =>
+        set(
+          (state): ImmerSetReturnType => ({
+            dataverse: [...state.dataverse, ...newDataverse]
+          })
+        ),
+      loadDataverse: (): T.Task<void> | void => {
+        const { addToDataverse, query, dataverse } = get()
+        const { setIsLoading, setHasNext, setError, limit, language, filters } = query
+        const offset = dataverse.length
+
+        setIsLoading(true)
+        setError(null)
+
+        const checkLanguageInvariant = (): E.Either<Error, void> =>
+          pipe(
+            E.tryCatch(
+              () => {
+                if (!language.length) {
+                  throw new Error(
+                    'Oops.. An error occurred when trying to load Dataverse.. Language cannot be empty..'
+                  )
+                }
+              },
+              reason =>
+                reason instanceof Error
+                  ? reason
+                  : new Error('Oops.. An unspecified error occurred..')
+            )
+          )
+
+        const fetchDataverse = (): T.Task<void> =>
+          pipe(
+            gateway.retrieveDataverse(language, limit, offset, filters),
+            TE.match(
+              e => {
+                setIsLoading(false)
+                setError(e)
+              },
+              r => {
+                setIsLoading(false)
+                setHasNext(r.query.hasNext)
+                addToDataverse(r.data)
+              }
+            )
+          )
+
+        return pipe(
+          checkLanguageInvariant(),
+          E.matchW(e => setError(e), fetchDataverse)
+        )
+      }
+    }))
+  )

--- a/src/domain/dataverse/dto.ts
+++ b/src/domain/dataverse/dto.ts
@@ -1,0 +1,9 @@
+export type DataverseDTO = Array<{
+  id: string
+  properties: DataverseDTOMetadata[]
+}>
+
+export type DataverseDTOMetadata = {
+  property: string
+  value: string
+}

--- a/src/domain/dataverse/entity.ts
+++ b/src/domain/dataverse/entity.ts
@@ -1,0 +1,13 @@
+export type DataverseElementId = string
+
+export type DataverseEntity = DataverseElement[]
+
+export type DataverseElement = {
+  id: DataverseElementId
+  properties: DataverseElementMetadata[]
+}
+
+type DataverseElementMetadata = {
+  property: string
+  value: string
+}

--- a/src/domain/dataverse/port.ts
+++ b/src/domain/dataverse/port.ts
@@ -2,7 +2,7 @@ import type * as TE from 'fp-ts/TaskEither'
 import type { DataverseEntity } from '@/domain/dataverse/entity'
 
 export type RetrieveDataverseQueryFilters = {
-  byType?: 'all' | 'DataSpace' | 'Dataset' | 'Service'
+  byType: 'all' | 'DataSpace' | 'Dataset' | 'Service'
 }
 
 export type RetrieveDataverseResult = { data: DataverseEntity; query: { hasNext: boolean } }
@@ -12,6 +12,6 @@ export type DataversePort = {
     language: string,
     limit: number,
     offset: number,
-    filters?: RetrieveDataverseQueryFilters
+    filters: RetrieveDataverseQueryFilters
   ) => TE.TaskEither<Error, RetrieveDataverseResult>
 }

--- a/src/domain/dataverse/port.ts
+++ b/src/domain/dataverse/port.ts
@@ -1,0 +1,17 @@
+import type * as TE from 'fp-ts/TaskEither'
+import type { DataverseEntity } from '@/domain/dataverse/entity'
+
+export type RetrieveDataverseQueryFilters = {
+  byType?: 'all' | 'DataSpace' | 'Dataset' | 'Service'
+}
+
+export type RetrieveDataverseResult = { data: DataverseEntity; query: { hasNext: boolean } }
+
+export type DataversePort = {
+  retrieveDataverse: (
+    language: string,
+    limit: number,
+    offset: number,
+    filters?: RetrieveDataverseQueryFilters
+  ) => TE.TaskEither<Error, RetrieveDataverseResult>
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,4 +8,5 @@ declare const APP_ENV: {
     | 'about:okp4',
     string
   >
+  sparql: Record<'endpoint' | 'credentials', string>
 }

--- a/src/infra/dataverse/sparql/dto.ts
+++ b/src/infra/dataverse/sparql/dto.ts
@@ -1,0 +1,22 @@
+export type SparqlResult = {
+  results: {
+    bindings: SparqlBinding[]
+  }
+}
+
+type SparqlBindingProperty = {
+  type: string
+  value: string
+}
+
+export type SparqlBinding = {
+  id: SparqlBindingProperty
+  metadata: SparqlBindingProperty
+  type: SparqlBindingProperty
+  title: SparqlBindingProperty & {
+    'xml:lang': string
+  }
+  description: SparqlBindingProperty & {
+    'xml:lang': string
+  }
+}

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -16,7 +16,7 @@ export const sparqlGateway: DataversePort = {
     language: string,
     limit: number,
     offset: number,
-    filters?: RetrieveDataverseQueryFilters
+    filters: RetrieveDataverseQueryFilters
   ): TE.TaskEither<Error, RetrieveDataverseResult> => {
     const query = `
       PREFIX core: <https://ontology.okp4.space/core/>
@@ -37,11 +37,7 @@ export const sparqlGateway: DataversePort = {
           ?id rdf:type core:DataSpace .
           ?metadata rdf:type dataspaceMetadata:GeneralMetadata .
         }
-        ${
-          filters && filters.byType !== 'all'
-            ? `FILTER ( contains(str(?type), "${filters.byType}" ))`
-            : ''
-        }
+        ${filters.byType !== 'all' ? `FILTER ( contains(str(?type), "${filters.byType}" ))` : ''}
         ?id rdf:type ?type .
         ?type rdf:type owl:Class .
         ?metadata core:describes ?id .

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -1,0 +1,146 @@
+/* eslint-disable max-lines-per-function */
+import * as A from 'fp-ts/lib/Array'
+import { flow, pipe } from 'fp-ts/lib/function'
+import * as O from 'fp-ts/lib/Option'
+import * as TE from 'fp-ts/TaskEither'
+import type { DataverseEntity } from '@/domain/dataverse/entity'
+import type {
+  DataversePort,
+  RetrieveDataverseQueryFilters,
+  RetrieveDataverseResult
+} from '@/domain/dataverse/port'
+import type { SparqlBinding, SparqlResult } from './dto'
+
+export const sparqlGateway: DataversePort = {
+  retrieveDataverse: (
+    language: string,
+    limit: number,
+    offset: number,
+    filters?: RetrieveDataverseQueryFilters
+  ): TE.TaskEither<Error, RetrieveDataverseResult> => {
+    const query = `
+      PREFIX core: <https://ontology.okp4.space/core/>
+      PREFIX owl: <http://www.w3.org/2002/07/owl#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX serviceMetadata: <https://ontology.okp4.space/metadata/service/>
+      PREFIX datasetMetadata: <https://ontology.okp4.space/metadata/dataset/>
+      PREFIX dataspaceMetadata: <https://ontology.okp4.space/metadata/dataspace/>
+      SELECT ?id ?metadata ?title ?description ?type
+      WHERE {
+        {
+          ?id rdf:type core:Service .
+          ?metadata rdf:type serviceMetadata:GeneralMetadata .
+        } UNION {
+          ?id rdf:type core:Dataset .
+          ?metadata rdf:type datasetMetadata:GeneralMetadata .
+        } UNION {          
+          ?id rdf:type core:DataSpace .
+          ?metadata rdf:type dataspaceMetadata:GeneralMetadata .
+        }
+        ${
+          filters && filters.byType !== 'all'
+            ? `FILTER ( contains(str(?type), "${filters.byType}" ))`
+            : ''
+        }
+        ?id rdf:type ?type .
+        ?type rdf:type owl:Class .
+        ?metadata core:describes ?id .
+        ?metadata core:hasTitle ?title .
+        ?metadata core:hasDescription ?description .
+        FILTER ( langMatches(lang(?title),'${language}') && langMatches(lang(?description),'${language}') )
+      }
+      LIMIT ${limit}
+      OFFSET ${offset}
+`
+
+    const fetchHeaders: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${APP_ENV.sparql['credentials']}`,
+        accept: 'application/sparql-results+json'
+      },
+      body: `query=${encodeURIComponent(query)}`
+    }
+
+    const fetchDataverse = (): TE.TaskEither<Error, Response> =>
+      TE.tryCatch(
+        async () => fetch(APP_ENV.sparql['endpoint'], fetchHeaders),
+        reason =>
+          reason instanceof Error
+            ? reason
+            : new Error(`Oops.. Something went wrong fetching ontology: ${JSON.stringify(reason)}`)
+      )
+
+    const serializeResponse = (response: Response): TE.TaskEither<Error, SparqlResult> =>
+      TE.tryCatch(
+        async () => response.json(),
+        reason =>
+          reason instanceof Error
+            ? reason
+            : new Error(
+                `Oops.. Something went wrong serializing sparql response: ${JSON.stringify(reason)}`
+              )
+      )
+
+    const splitBindingId = (b: SparqlBinding): O.Option<[SparqlBinding, string]> =>
+      pipe(
+        O.fromNullable(b.id.value.split('/').at(-1)),
+        O.map(a => [b, a])
+      )
+
+    const splitBindingType = ([b, a]: [SparqlBinding, string]): O.Option<
+      [SparqlBinding, string, string]
+    > =>
+      pipe(
+        O.fromNullable(b.type.value.split('/').at(-1)),
+        O.map(c => [b, a, c])
+      )
+
+    const getDataverseEntityLengthOption = O.fromPredicate(
+      (dataverseEntity: DataverseEntity) => dataverseEntity.length === limit
+    )
+    const filterDataverseEntity = (dataverseEntity: DataverseEntity): DataverseEntity =>
+      pipe(
+        dataverseEntity,
+        getDataverseEntityLengthOption,
+        O.match(
+          () => dataverseEntity,
+          e => A.dropRight(1)(e)
+        )
+      )
+
+    const mapDtoToEntity = (dto: SparqlResult): DataverseEntity =>
+      pipe(
+        dto.results.bindings,
+        A.filterMap(splitBindingId),
+        A.filterMap(splitBindingType),
+        A.map(([{ title, description }, id, type]) => {
+          return {
+            id,
+            properties: [
+              { property: 'title', value: title.value },
+              {
+                property: 'type',
+                value: type
+              },
+              {
+                property: 'description',
+                value: description.value
+              }
+            ]
+          }
+        })
+      )
+
+    return pipe(
+      fetchDataverse(),
+      TE.chain(serializeResponse),
+      TE.chain<Error, SparqlResult, { data: DataverseEntity; query: { hasNext: boolean } }>(
+        flow(mapDtoToEntity, r =>
+          TE.right({ data: filterDataverseEntity(r), query: { hasNext: r.length === limit } })
+        )
+      )
+    )
+  }
+}

--- a/src/ui/store/index.ts
+++ b/src/ui/store/index.ts
@@ -1,0 +1,6 @@
+import { dataverseAggregate } from '@/domain/dataverse/aggregate'
+import type { DataverseStore } from '@/domain/dataverse/aggregate'
+import { sparqlGateway } from '@/infra/dataverse/sparql/sparqlGateway'
+import type { StoreApi } from 'zustand'
+
+export const dataverseStore = dataverseAggregate(sparqlGateway) as StoreApi<DataverseStore>


### PR DESCRIPTION
ℹ️ This PR adds the `dataverse` core logic domain that allows to retrieve the whole `dataverse` into ontology database.

⚙️This mechanism is based on two principles:

- a `domain` layer that contains the whole elements related to the `dataverse` bounded context. (aggregate)
- an `infrastructure` layer  that allows the domain to communicate with the outside.

🧠 Those two mechanisms work together to: fetch elements in the ontology, map them and compute them to be consumed by any controller.

The controller has access to a public contract interface (store) that provides the base getters (reactive selectors) and setters to perform actions.

🔜 Views must me updated to consume data from the store, regarding the contract specifications.

