### PR TITLE
refactor: improve syntax

### DIFF
--- a/src/ui/i18n/translations/common_de.json
+++ b/src/ui/i18n/translations/common_de.json
@@ -12,7 +12,7 @@
     "lastUpdate": "Letzte Aktualisierung"
   },
   "actions": {
-    "explore": "Erkunden Sie",
+    "explore": "Dataverse erkunden",
     "details": "Siehe Details",
     "accessGovernance": "Auf Governance zugreifen"
   },

--- a/src/ui/i18n/translations/common_en.json
+++ b/src/ui/i18n/translations/common_en.json
@@ -12,7 +12,7 @@
     "lastUpdate": "Last update"
   },
   "actions": {
-    "explore": "Explore",
+    "explore": "Explore dataverse",
     "details": "See Details",
     "accessGovernance": "Access governance"
   },

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -12,7 +12,7 @@
     "lastUpdate": "Dernière mise à jour"
   },
   "actions": {
-    "explore": "Explorer",
+    "explore": "Explorer le dataverse",
     "details": "Voir Détails",
     "accessGovernance": "Accéder à la gouvernance"
   },

--- a/src/ui/page/home/i18n/home_de.json
+++ b/src/ui/page/home/i18n/home_de.json
@@ -11,8 +11,8 @@
         }
       },
       "explore": {
-        "label": "Erkunden Sie",
-        "catalog": "Den Katalog erforschen"
+        "label": "Dataverse erkunden ",
+        "catalog": "Dataverse durchsuchen"
       },
       "interact": {
         "label": "Interagieren",

--- a/src/ui/page/home/i18n/home_en.json
+++ b/src/ui/page/home/i18n/home_en.json
@@ -11,8 +11,8 @@
         }
       },
       "explore": {
-        "label": "Explore",
-        "catalog": "Explore the catalog"
+        "label": "Explore dataverse",
+        "catalog": "Browse dataverse"
       },
       "interact": {
         "label": "Interact",

--- a/src/ui/page/home/i18n/home_fr.json
+++ b/src/ui/page/home/i18n/home_fr.json
@@ -11,8 +11,8 @@
         }
       },
       "explore": {
-        "label": "Explorer",
-        "catalog": "Explorer le catalogue"
+        "label": "Explorer le dataverse",
+        "catalog": "Naviguer sur le dataverse"
       },
       "interact": {
         "label": "Interagir",


### PR DESCRIPTION
This PR fixes the syntax issues mentioned in the following ticket: #178 

Basically, it changes the "Explore" titles to "Explore dataverse", and changes the Home explore button name "Explore catalog" to "Browse dataverse" as well as their corresponding translation files. 

## Screenshots

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/83208740/233039309-12ff243d-9998-4f96-86af-f80bfa2e1cab.png">

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/83208740/233039416-9f91a821-bc50-42f7-b20e-fffa0ba5bb34.png">
