### PR TITLE
chore: prevent production logs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,23 +8,19 @@ import htmlConfigOptions from './config/html-config'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    htmlConfig(htmlConfigOptions),
-    react(), 
-    svgr()
-  ],
+  plugins: [htmlConfig(htmlConfigOptions), react(), svgr()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')
     }
   },
   build: {
-      rollupOptions: {
-        output: {
-          manualChunks: {
-            'react-vendor': ['react', 'react-dom', 'react-router-dom']
-          }
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom']
         }
       }
-    },
+    }
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,15 @@ import htmlConfig from 'vite-plugin-html-config'
 import htmlConfigOptions from './config/html-config'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [htmlConfig(htmlConfigOptions), react(), svgr()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')
     }
+  },
+  esbuild: {
+    drop: mode === 'production' ? ['console', 'debugger'] : []
   },
   build: {
     rollupOptions: {
@@ -23,4 +26,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
This PR implements https://github.com/okp4/dataverse-portal/issues/179.

### How to test it locally?
From this branch `chore/prevent-production-logs`,
- add some console.logs whenever you want and test them locally with `npm run dev` (port 5173).
- build your app with `npm run build`, then launch and test it with `npm run preview` (port 4173).