### PR TITLE
Fix: add key property on nav item div element

### DIFF
--- a/src/ui/component/sidebar/navigation/navigation.tsx
+++ b/src/ui/component/sidebar/navigation/navigation.tsx
@@ -109,7 +109,7 @@ export const Navigation: FC = () => {
                 }
               </NavLink>
             ) : (
-              <div className="okp4-dataverse-portal-sidebar-deactivated-navitem">
+              <div className="okp4-dataverse-portal-sidebar-deactivated-navitem" key={id}>
                 {renderNavitem(isSidebarExpanded, label, id)}
               </div>
             )


### PR DESCRIPTION
This PR add a missing key to the elements within to the main Navigation.

Thus it removes the warning related to the Navigation displayed in dev environment:
![image](https://user-images.githubusercontent.com/8344874/233371581-a231790a-1c0c-48e5-a11f-a9a8300cf317.png)
