### PR TITLE
Refactor/remove unnecessary navigation state for active sections

### DIFF
--- a/src/ui/page/dataverse/dataspace/governance/governance.tsx
+++ b/src/ui/page/dataverse/dataspace/governance/governance.tsx
@@ -91,7 +91,6 @@ export const Governance: FC = () => {
         <h1>{`${dataspaceLabel} | ${t('resources.governance')}`}</h1>
         <GovernanceNavigation
           activeSectionId={currentSection.id}
-          activeSubsectionId={currentSubsection.id}
           dataspaceId={dataspaceId}
           sections={sections}
         />

--- a/src/ui/page/dataverse/dataspace/governance/governance.tsx
+++ b/src/ui/page/dataverse/dataspace/governance/governance.tsx
@@ -90,10 +90,10 @@ export const Governance: FC = () => {
       <section className="okp4-dataverse-portal-governance-page-section">
         <h1>{`${dataspaceLabel} | ${t('resources.governance')}`}</h1>
         <GovernanceNavigation
+          activeSectionId={currentSection.id}
+          activeSubsectionId={currentSubsection.id}
           dataspaceId={dataspaceId}
-          sectionId={currentSection.id}
           sections={sections}
-          subsectionId={currentSubsection.id}
         />
         <GovernanceDetails section={currentSection} subSection={currentSubsection} />
       </section>

--- a/src/ui/page/dataverse/dataspace/governance/governanceNavigation.tsx
+++ b/src/ui/page/dataverse/dataspace/governance/governanceNavigation.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines-per-function */
 import type { FC } from 'react'
-import { useEffect, useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { NavLink } from 'react-router-dom'
 import classnames from 'classnames'
 import { useAppStore } from '@/ui/store/appStore'
@@ -11,38 +11,17 @@ import type { SectionDTO } from './mockedData'
 type GovernanceWithNavigationProps = {
   dataspaceId: string
   sections: SectionDTO[]
-  sectionId: string
-  subsectionId: string
+  activeSectionId: string
+  activeSubsectionId: string
 }
 
 export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
   dataspaceId,
   sections,
-  sectionId,
-  subsectionId
+  activeSectionId,
+  activeSubsectionId
 }) => {
   const theme = useAppStore(state => state.theme)
-
-  const [activeSectionId, setActiveSectionId] = useState<string>(sectionId)
-  const [activeSubsectionId, setActiveSubsectionId] = useState<string>(subsectionId)
-  useEffect(() => {
-    setActiveSectionId(sectionId)
-    setActiveSubsectionId(subsectionId)
-  }, [sectionId, subsectionId])
-
-  const handleNavSectionClick = useCallback(
-    (section: SectionDTO) => () => {
-      setActiveSectionId(section.id)
-      setActiveSubsectionId(section.contains[0].id)
-    },
-    []
-  )
-  const handleNavSubsectionClick = useCallback(
-    (sectionId: string, subsectionId: string) => () => {
-      setActiveSubsectionId(subsectionId)
-    },
-    []
-  )
 
   const navLinkClassName = useCallback(
     ({ isActive }: { isActive: boolean }) => (isActive ? 'active' : undefined),
@@ -54,8 +33,7 @@ export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
   return (
     <nav className="okp4-dataverse-portal-governance-page-navigation">
       <ul className="okp4-dataverse-portal-governance-page-navigation-section-list">
-        {sections.map(section => {
-          const { id: sectionId, title: sectionTitle, contains: subsections } = section
+        {sections.map(({ title: sectionTitle, contains: subsections, id: sectionId }) => {
           const isSectionActive = sectionId === activeSectionId
           const hasMoreThanOneSubsection = subsections.length > 1
           return (
@@ -68,7 +46,6 @@ export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
                   'okp4-dataverse-portal-governance-page-navigation-section-link',
                   navLinkClassName({ isActive: isSectionActive })
                 )}
-                onClick={handleNavSectionClick(section)}
                 to={`${governanceBasePath}/${sectionId}/${subsections[0].id}`}
               >
                 {sectionTitle}
@@ -79,29 +56,25 @@ export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
                   hasMoreThanOneSubsection && isSectionActive ? 'visible' : 'hidden'
                 )}
               >
-                {subsections.map(({ title: subsectionTitle, id: subsectionId }) => {
-                  const isSubsectionActive = subsectionId === activeSubsectionId
-                  return (
-                    <li
-                      className="okp4-dataverse-portal-governance-page-navigation-subsection-list-item"
-                      key={subsectionId}
+                {subsections.map(({ title: subsectionTitle, id: subsectionId }) => (
+                  <li
+                    className="okp4-dataverse-portal-governance-page-navigation-subsection-list-item"
+                    key={subsectionId}
+                  >
+                    <div className="okp4-dataverse-portal-governance-page-navigation-subsection-list-style">
+                      <Icon name={`hook-${theme}` as IconName} />
+                    </div>
+                    <NavLink
+                      className={classnames(
+                        'okp4-dataverse-portal-governance-page-navigation-subsection-link',
+                        navLinkClassName({ isActive: subsectionId === activeSubsectionId })
+                      )}
+                      to={`${governanceBasePath}/${sectionId}/${subsectionId}`}
                     >
-                      <div className="okp4-dataverse-portal-governance-page-navigation-subsection-list-style">
-                        <Icon name={`hook-${theme}` as IconName} />
-                      </div>
-                      <NavLink
-                        className={classnames(
-                          'okp4-dataverse-portal-governance-page-navigation-subsection-link',
-                          navLinkClassName({ isActive: isSubsectionActive })
-                        )}
-                        onClick={handleNavSubsectionClick(sectionId, subsectionId)}
-                        to={`${governanceBasePath}/${sectionId}/${subsectionId}`}
-                      >
-                        {subsectionTitle}
-                      </NavLink>
-                    </li>
-                  )
-                })}
+                      {subsectionTitle}
+                    </NavLink>
+                  </li>
+                ))}
               </ul>
             </li>
           )

--- a/src/ui/page/dataverse/dataspace/governance/governanceNavigation.tsx
+++ b/src/ui/page/dataverse/dataspace/governance/governanceNavigation.tsx
@@ -12,14 +12,12 @@ type GovernanceWithNavigationProps = {
   dataspaceId: string
   sections: SectionDTO[]
   activeSectionId: string
-  activeSubsectionId: string
 }
 
 export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
   dataspaceId,
   sections,
-  activeSectionId,
-  activeSubsectionId
+  activeSectionId
 }) => {
   const theme = useAppStore(state => state.theme)
 
@@ -67,7 +65,7 @@ export const GovernanceNavigation: FC<GovernanceWithNavigationProps> = ({
                     <NavLink
                       className={classnames(
                         'okp4-dataverse-portal-governance-page-navigation-subsection-link',
-                        navLinkClassName({ isActive: subsectionId === activeSubsectionId })
+                        { navLinkClassName }
                       )}
                       to={`${governanceBasePath}/${sectionId}/${subsectionId}`}
                     >


### PR DESCRIPTION
This PR removes the governance navigation state management. This state is not required because active links are managed from component props. The router manage and to pass these props from the governance component. Thanks @fredericvilcot for [pointing this out](https://github.com/okp4/dataverse-portal/pull/180#discussion_r1172545430)!

