### PR TITLE
Chore/update pnpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.27.0
+          version: 8.3.0
 
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
           node-version: 16.19
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.27.0
+          version: 8.3.0
 
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
@@ -114,7 +114,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.27.0
+          version: 8.3.0
 
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.27.0
+          version: 8.3.0
 
       - name: Setup node environment
         uses: actions/setup-node@v3
         with:
           node-version: 16.19
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Fetch dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.19-alpine as build
 
-RUN npm install -g pnpm@7.27.0
+RUN npm install -g pnpm@8.3.1
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "engines": {
     "node": "^16.19",
-    "pnpm": "^7.27.0"
+    "pnpm": "^8.3.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Regarding this [PR](https://github.com/okp4/dataverse-portal/pull/193), `pnpm-lock.yaml` has been updated to version 6 (`lockfileVersion`), so to be compliant with it, we need to use new version of `pnpm`.