### PR TITLE
fix: make dataverse back button text clickable

### DIFF
--- a/src/ui/view/dataverse/component/backButton/backButton.scss
+++ b/src/ui/view/dataverse/component/backButton/backButton.scss
@@ -24,11 +24,13 @@
     }
 
     .okp4-dataverse-portal-button-main {
-      .okp4-dataverse-portal-button-label.outlined-tertiary {
-        @include noto-sans(700);
-        font-size: 14px;
-        line-height: 22px;
-        color: themed('text');
+      .okp4-dataverse-portal-button-label {
+        &.outlined-tertiary {
+          @include noto-sans(700);
+          font-size: 14px;
+          line-height: 22px;
+          color: themed('text');
+        }
       }
     }
   }

--- a/src/ui/view/dataverse/component/backButton/backButton.scss
+++ b/src/ui/view/dataverse/component/backButton/backButton.scss
@@ -23,11 +23,13 @@
       }
     }
 
-    .okp4-dataverse-portal-back-text {
-      @include noto-sans(700);
-      font-size: 14px;
-      line-height: 22px;
-      color: themed('text');
+    .okp4-dataverse-portal-button-main {
+      .okp4-dataverse-portal-button-label.outlined-tertiary {
+        @include noto-sans(700);
+        font-size: 14px;
+        line-height: 22px;
+        color: themed('text');
+      }
     }
   }
 }

--- a/src/ui/view/dataverse/component/backButton/backButton.tsx
+++ b/src/ui/view/dataverse/component/backButton/backButton.tsx
@@ -21,11 +21,11 @@ export const BackButton: FC<BackButtonProps> = ({ to, label }): JSX.Element => {
     <div className="okp4-dataverse-portal-back-main">
       <Button
         className="okp4-dataverse-portal-back-button"
-        iconButtonOnly={<Icon name="arrow-left" />}
+        icons={{ startIcon: <Icon name="arrow-left" /> }}
+        label={label}
         onClick={handleRouting}
         variant="outlined-tertiary"
       />
-      {label && <p className="okp4-dataverse-portal-back-text">{label}</p>}
     </div>
   )
 }


### PR DESCRIPTION
This PR makes the whole dataverse back button clickable, including the text. Previously only the arrow icon was clickable, not the "Dataverse" text as well. 