### PR TITLE
Chore/update dev server script in order to listen on LAN addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pnpm": "^8.3.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "jest",


### PR DESCRIPTION
In order to make tests on local devices (mobile, tablet, etc...), the dev server needs to listen on LAN addresses.

[See more](https://vitejs.dev/config/server-options.html) about the Vite server configuration.