### PR TITLE
Fix/error page flashing on dataverse item card selection

### DIFF
--- a/src/ui/page/dataverse/dataset/dataset.tsx
+++ b/src/ui/page/dataverse/dataset/dataset.tsx
@@ -100,7 +100,6 @@ const Dataset: FC = () => {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    setIsLoading(true)
     const resourceDetails = id ? getResourceDetails(id) : O.none
     setDataset(
       O.isSome(resourceDetails) && isDataSet(resourceDetails.value) ? resourceDetails : O.none

--- a/src/ui/page/dataverse/dataset/dataset.tsx
+++ b/src/ui/page/dataverse/dataset/dataset.tsx
@@ -1,7 +1,7 @@
+import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import type { Option } from 'fp-ts/Option'
-import { match, none } from 'fp-ts/Option'
+import * as O from 'fp-ts/Option'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
@@ -91,15 +91,23 @@ const datasetMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
-const Dataset = (): JSX.Element => {
+const Dataset: FC = () => {
   const { id } = useParams<string>()
-  const [dataset, setDataset] = useState<Option<DataverseItemDetails>>(none)
+  const [dataset, setDataset] = useState<O.Option<DataverseItemDetails>>(O.none)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    id && setDataset(getResourceDetails(id))
+    setIsLoading(true)
+    setDataset(id ? getResourceDetails(id) : O.none)
+    setIsLoading(false)
   }, [id])
 
-  return match(
+  if (isLoading) {
+    // TODO: add loading component
+    return null
+  }
+
+  return O.match(
     () => <NotFoundError />,
     (dataset: DataverseItemDetails) => <PageTemplate data={dataset} metadata={datasetMetadata} />
   )(dataset)

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -1,13 +1,12 @@
+import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import type { Option } from 'fp-ts/Option'
+import * as O from 'fp-ts/Option'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
 import type { DataSpace, DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
-import * as O from 'fp-ts/Option'
-import { pipe } from 'fp-ts/lib/function'
 
 const dataspaceMetadata: ItemGeneralMetadata[] = [
   {
@@ -60,17 +59,27 @@ const dataspaceMetadata: ItemGeneralMetadata[] = [
 export const isDataSpace = (resource: DataverseItemDetails): resource is DataSpace =>
   resource.type === 'dataspace'
 
-const Dataspace = (): JSX.Element => {
+const Dataspace: FC = () => {
   const { id } = useParams<string>()
-  const [dataspace, setDataspace] = useState<Option<DataSpace>>(O.none)
+  const [dataspace, setDataspace] = useState<O.Option<DataverseItemDetails>>(O.none)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
 
   useEffect(() => {
-    pipe(O.fromNullable(id), O.flatMap(getResourceDetails), O.filter(isDataSpace), setDataspace)
+    setIsLoading(true)
+    setDataspace(id ? getResourceDetails(id) : O.none)
+    setIsLoading(false)
   }, [id])
+
+  if (isLoading) {
+    // TODO: add loading component
+    return null
+  }
 
   return O.match(
     () => <NotFoundError />,
-    (dataspace: DataSpace) => <PageTemplate data={dataspace} metadata={dataspaceMetadata} />
+    (dataspace: DataverseItemDetails) => (
+      <PageTemplate data={dataspace} metadata={dataspaceMetadata} />
+    )
   )(dataspace)
 }
 

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -65,7 +65,6 @@ const Dataspace: FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true)
 
   useEffect(() => {
-    setIsLoading(true)
     const resourceDetails = id ? getResourceDetails(id) : O.none
     setDataspace(
       O.isSome(resourceDetails) && isDataSpace(resourceDetails.value) ? resourceDetails : O.none

--- a/src/ui/page/dataverse/service/service.tsx
+++ b/src/ui/page/dataverse/service/service.tsx
@@ -1,7 +1,7 @@
+import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import type { Option } from 'fp-ts/Option'
-import { match, none } from 'fp-ts/Option'
+import * as O from 'fp-ts/Option'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
 import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
@@ -66,15 +66,23 @@ const serviceGeneralMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
-const Service = (): JSX.Element => {
+const Service: FC = () => {
   const { id } = useParams<string>()
-  const [service, setService] = useState<Option<DataverseItemDetails>>(none)
+  const [service, setService] = useState<O.Option<DataverseItemDetails>>(O.none)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    id && setService(getResourceDetails(id))
+    setIsLoading(true)
+    setService(id ? getResourceDetails(id) : O.none)
+    setIsLoading(false)
   }, [id])
 
-  return match(
+  if (isLoading) {
+    // TODO: add loading component
+    return null
+  }
+
+  return O.match(
     () => <NotFoundError />,
     (service: DataverseItemDetails) => (
       <PageTemplate data={service} metadata={serviceGeneralMetadata} />

--- a/src/ui/page/dataverse/service/service.tsx
+++ b/src/ui/page/dataverse/service/service.tsx
@@ -75,7 +75,6 @@ const Service: FC = () => {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    setIsLoading(true)
     const resourceDetails = id ? getResourceDetails(id) : O.none
     setService(
       O.isSome(resourceDetails) && isService(resourceDetails.value) ? resourceDetails : O.none


### PR DESCRIPTION
This PR fixes https://github.com/okp4/dataverse-portal/issues/232.

By fixing this bug, I realised we can get any dataverse item resource, not matter the path we are using.
e. g. `/dataverse/dataset/2` or `/dataverse/service/2` will give the dataverse item of id 2, which shouldn't be the case for the `service` path.
A [PR](https://github.com/okp4/dataverse-portal/pull/255) has been created to address this issue.