### PR TITLE
build(deps): bump fp-ts version to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint --fix src/**/*.{ts,tsx} && stylelint --fix '**/*.scss'"
   },
   "dependencies": {
-    "fp-ts": "^2.14.0",
+    "fp-ts": "^2.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   fp-ts:
-    specifier: ^2.14.0
-    version: 2.14.0
+    specifier: ^2.15.0
+    version: 2.15.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -2891,8 +2891,8 @@ packages:
       mime-types: 2.1.35
     dev: true
 
-  /fp-ts@2.14.0:
-    resolution: {integrity: sha512-QLagLSYAgMA00pZzUzeksH/78Sd14y7+Gc2A8Yaja3/IpGOFMdm/gYBuDMxYqLsJ58iT5lz+bJb953RAeFfp1A==}
+  /fp-ts@2.15.0:
+    resolution: {integrity: sha512-3o6EllAvGuCsDgjM+frscLKDRPR9pqbrg13tJ13z86F4eni913kBV8h85rM6zpu2fEvJ8RWA0ouYlUWwHEmxTg==}
     dev: false
 
   /fs.realpath@1.0.0:


### PR DESCRIPTION
Self explanatory.

PS:
- this should have been proposed by `dependabot`, but I don't know why it is not
- the [fp-ts official documentation](https://gcanti.github.io/fp-ts/) refers to a version `v2.16`, but it seems not currently available. To be followed.
