### PR TITLE
Fix/dataverse resource path

### DIFF
--- a/src/ui/page/dataverse/dataset/dataset.tsx
+++ b/src/ui/page/dataverse/dataset/dataset.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import * as O from 'fp-ts/Option'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
-import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
+import { Dataset, getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
@@ -91,6 +91,9 @@ const datasetMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
+const isDataSet = (resource: DataverseItemDetails): resource is Dataset =>
+  resource.type === 'dataset'
+
 const Dataset: FC = () => {
   const { id } = useParams<string>()
   const [dataset, setDataset] = useState<O.Option<DataverseItemDetails>>(O.none)
@@ -98,7 +101,10 @@ const Dataset: FC = () => {
 
   useEffect(() => {
     setIsLoading(true)
-    setDataset(id ? getResourceDetails(id) : O.none)
+    const resourceDetails = id ? getResourceDetails(id) : O.none
+    setDataset(
+      O.isSome(resourceDetails) && isDataSet(resourceDetails.value) ? resourceDetails : O.none
+    )
     setIsLoading(false)
   }, [id])
 

--- a/src/ui/page/dataverse/dataspace/dataspace.tsx
+++ b/src/ui/page/dataverse/dataspace/dataspace.tsx
@@ -66,7 +66,10 @@ const Dataspace: FC = () => {
 
   useEffect(() => {
     setIsLoading(true)
-    setDataspace(id ? getResourceDetails(id) : O.none)
+    const resourceDetails = id ? getResourceDetails(id) : O.none
+    setDataspace(
+      O.isSome(resourceDetails) && isDataSpace(resourceDetails.value) ? resourceDetails : O.none
+    )
     setIsLoading(false)
   }, [id])
 

--- a/src/ui/page/dataverse/service/service.tsx
+++ b/src/ui/page/dataverse/service/service.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import * as O from 'fp-ts/Option'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
-import { getResourceDetails } from '@/ui/page/dataverse/dataverse'
+import { Service, getResourceDetails } from '@/ui/page/dataverse/dataverse'
 import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
@@ -66,6 +66,9 @@ const serviceGeneralMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
+const isService = (resource: DataverseItemDetails): resource is Service =>
+  resource.type === 'service'
+
 const Service: FC = () => {
   const { id } = useParams<string>()
   const [service, setService] = useState<O.Option<DataverseItemDetails>>(O.none)
@@ -73,7 +76,10 @@ const Service: FC = () => {
 
   useEffect(() => {
     setIsLoading(true)
-    setService(id ? getResourceDetails(id) : O.none)
+    const resourceDetails = id ? getResourceDetails(id) : O.none
+    setService(
+      O.isSome(resourceDetails) && isService(resourceDetails.value) ? resourceDetails : O.none
+    )
     setIsLoading(false)
   }, [id])
 


### PR DESCRIPTION
This PR fixes the dataverse resource pages that must display a not found error when the resource `id` doesn't match the type of resource. More details in [this PR description](https://github.com/okp4/dataverse-portal/pull/250#issue-1722102167).