### PR TITLE
fix: update dataverse items data in explore page

### DIFF
--- a/src/ui/page/home/explore/explore.tsx
+++ b/src/ui/page/home/explore/explore.tsx
@@ -11,28 +11,32 @@ import { routes } from '@/ui/routes'
 
 const exploreItems: DataverseItemCardProps[] = [
   {
-    id: '1',
+    id: 'ef347285-e52a-430d-9679-dcb76b962ce7',
     type: 'dataspace',
     label: 'Rhizome',
-    description: 'Agriculture, Food, Environment and Forestry'
+    description:
+      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.'
   },
   {
-    id: '13',
+    id: '957df710-4e35-45fb-add8-34d49904a77a',
     type: 'dataset',
     label: 'Agreste 2020',
-    description: 'Agriculture, Food, Environment and Forestry'
+    description:
+      'Annual agricultural statistics, consisting of the areas, yields and production of the French territory."'
   },
   {
-    id: '11',
+    id: '79ec2986-0d71-4e92-a48d-95379b3da9ed',
     type: 'dataset',
-    label: 'Graphical Plot Registry France 2020',
-    description: 'Agriculture, Food, Environment and Forestry'
+    label: 'ADMIN EXPRESS COG 2020 DEPARTMENT',
+    description:
+      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
   },
   {
-    id: '3',
+    id: '16c4cd10-521a-4829-b1bd-a1e2ac60459a',
     type: 'service',
     label: 'Data connector',
-    description: 'Data Integration'
+    description:
+      'This service allows you to inject data files into OpenSearch so that you can consume the knowledge created through visualization.'
   }
 ]
 


### PR DESCRIPTION
As the dataverse elements are now retrieved from the ontology, the fake dataverse element ids on the explore page are no longer relevant.
When the user clicks on the "View details" button of one of the 4 dataverse item cards in the explore part of the home page, we receive a 404 page because the existing id is not linked to any dataverse item.
This ontology query has not yet been implemented, so the fake dataverse items ids have been updated with those from the ontology.