### PR TITLE
Fix/incompatible timeout type that leads to build error

### DIFF
--- a/src/ui/hook/useTimeout.ts
+++ b/src/ui/hook/useTimeout.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react'
 type UseTimeout = () => void
 
 export const useTimeout = (callback: () => void, delay: number | null): UseTimeout => {
-  const timeoutRef = useRef<number | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const set = useCallback(() => {
     timeoutRef.current = delay !== null ? setTimeout(() => callback(), delay) : null


### PR DESCRIPTION
We are experiencing [build errors](https://github.com/okp4/dataverse-portal/actions/runs/5174292080/jobs/9320445838) due to this timeout type error.

This PR aims to fix it by providing the appropriate type.