### PR TITLE
Fix/dataverse topics

### DIFF
--- a/src/infra/dataverse/sparql/dto.ts
+++ b/src/infra/dataverse/sparql/dto.ts
@@ -16,8 +16,9 @@ export type SparqlBinding = {
   title: SparqlBindingProperty & {
     'xml:lang': string
   }
-  description: SparqlBindingProperty & {
+  publisher: SparqlBindingProperty
+  topic: SparqlBindingProperty
+  prefLabel: SparqlBindingProperty & {
     'xml:lang': string
   }
-  publisher: SparqlBindingProperty
 }

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -597,10 +597,10 @@ const Dataverse = (): JSX.Element => {
                 ? loadingDataverseCards
                 : dataverse()().map(({ id, properties }) => (
                     <DataverseItemCard
-                      description={properties.find(p => p.property === 'description')?.value ?? ''}
                       id={id}
                       key={id}
                       label={properties.find(p => p.property === 'title')?.value ?? ''}
+                      topic={properties.find(p => p.property === 'topic')?.value ?? ''}
                       type={
                         properties
                           .find(p => p.property === 'type')

--- a/src/ui/page/home/explore/explore.tsx
+++ b/src/ui/page/home/explore/explore.tsx
@@ -14,29 +14,25 @@ const exploreItems: DataverseItemCardProps[] = [
     id: 'ef347285-e52a-430d-9679-dcb76b962ce7',
     type: 'dataspace',
     label: 'Rhizome',
-    description:
-      'Rhizome is a data space operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry.'
+    topic: 'Agriculture, food, environment and forestry'
   },
   {
     id: '957df710-4e35-45fb-add8-34d49904a77a',
     type: 'dataset',
     label: 'Agreste 2020',
-    description:
-      'Annual agricultural statistics, consisting of the areas, yields and production of the French territory."'
+    topic: 'Agriculture, food, environment and forestry'
   },
   {
     id: '79ec2986-0d71-4e92-a48d-95379b3da9ed',
     type: 'dataset',
     label: 'ADMIN EXPRESS COG 2020 DEPARTMENT',
-    description:
-      'ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a "COG" edition, in accordance with the official geographic code published each year by INSEE.'
+    topic: 'Other'
   },
   {
     id: '16c4cd10-521a-4829-b1bd-a1e2ac60459a',
     type: 'service',
     label: 'Data connector',
-    description:
-      'This service allows you to inject data files into OpenSearch so that you can consume the knowledge created through visualization.'
+    topic: 'Data Integration'
   }
 ]
 
@@ -46,9 +42,9 @@ export const Explore: FC = () => {
   return (
     <>
       <h1>{t('home.blocks.explore.label')}</h1>
-      {exploreItems.map(({ id, type, description, label }) => (
+      {exploreItems.map(({ id, type, topic, label }) => (
         <div className="okp4-dataverse-portal-home-page-explore-card-wrapper" key={label}>
-          <DataverseItemCard description={description} id={id} label={label} type={type} />
+          <DataverseItemCard id={id} label={label} topic={topic} type={type} />
         </div>
       ))}
       <NavLink

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.scss
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.scss
@@ -38,8 +38,7 @@ $colors: (
       line-height: 24px;
       letter-spacing: 2px;
 
-      @each $color-key,
-        $color-value in $colors {
+      @each $color-key, $color-value in $colors {
         &.#{$color-key} {
           color: themed($color-key);
           background-color: themed($color-value);
@@ -60,7 +59,7 @@ $colors: (
         width: 88%;
       }
 
-      .okp4-dataverse-portal-dataverse-description {
+      .okp4-dataverse-portal-dataverse-topic {
         display: flex;
         flex-direction: column;
         width: 100%;

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -14,10 +14,10 @@ export type DataverseItemCardProps = {
   id: string
   type: DataverseItem
   label: string
-  description: string
+  topic: string
 }
 
-export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label, description }) => {
+export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label, topic }) => {
   const navigate = useNavigate()
   const { t } = useTranslation('common')
 
@@ -35,8 +35,8 @@ export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label,
   }, [])
 
   const renderItemContent = useCallback(
-    (label: string, description: string): string => `### ${label}
-${description}`,
+    (label: string, topic: string): string => `### ${label}
+${topic}`,
     []
   )
 
@@ -56,8 +56,8 @@ ${description}`,
           {t(`resources.${type}`)}
         </div>
         <div className="okp4-dataverse-portal-dataverse-item-card-content">
-          <div className="okp4-dataverse-portal-dataverse-description">
-            <ReactMarkdown>{renderItemContent(label, description)}</ReactMarkdown>
+          <div className="okp4-dataverse-portal-dataverse-topic">
+            <ReactMarkdown>{renderItemContent(label, topic)}</ReactMarkdown>
           </div>
           <Button label={t('actions.details')} onClick={handleDataverseItemDetails} />
         </div>


### PR DESCRIPTION
This PR aims to fix this [issue](#272), by replacing the `description` received from the ontology with the `topic` (for `datasets` and `dataspaces`) or the `category` (for `services`).

The `UI` part has been updated accordingly (`explore` cards and `home` page).

