### PR TITLE
Feat: add storage service selection page

### DIFF
--- a/src/ui/component/card/card.tsx
+++ b/src/ui/component/card/card.tsx
@@ -13,11 +13,15 @@ export type CardProps = {
   children: React.ReactElement
   background?: CardBackground
   mainClassName?: string
+  onClick?: () => void
 }
 
-export const Card: FC<CardProps> = ({ children, mainClassName, background = 'card' }) => {
+export const Card: FC<CardProps> = ({ children, mainClassName, onClick, background = 'card' }) => {
   return (
-    <div className={classNames('okp4-dataverse-portal-card-main', mainClassName, background)}>
+    <div
+      className={classNames('okp4-dataverse-portal-card-main', mainClassName, background)}
+      onClick={onClick}
+    >
       {children}
     </div>
   )

--- a/src/ui/i18n/translations/common_de.json
+++ b/src/ui/i18n/translations/common_de.json
@@ -23,5 +23,7 @@
   "from": "Von:",
   "to": "Bis:",
   "know": "Know",
-  "noResultsFound": "Keine Ergebnisse gefunden."
+  "noResultsFound": "Keine Ergebnisse gefunden.",
+  "select": "Auswählen",
+  "selected": "Ausgewählt"
 }

--- a/src/ui/i18n/translations/common_en.json
+++ b/src/ui/i18n/translations/common_en.json
@@ -23,5 +23,7 @@
   "from": "From:",
   "to": "To:",
   "know": "Know",
-  "noResultsFound": "No results found."
+  "noResultsFound": "No results found.",
+  "select": "Select",
+  "selected": "Selected"
 }

--- a/src/ui/i18n/translations/common_fr.json
+++ b/src/ui/i18n/translations/common_fr.json
@@ -23,5 +23,7 @@
   "from": "Depuis le :",
   "to": "Jusqu'au :",
   "know": "Know",
-  "noResultsFound": "Aucun résultat trouvé."
+  "noResultsFound": "Aucun résultat trouvé.",
+  "select": "Sélectionner",
+  "selected": "Sélectionné"
 }

--- a/src/ui/page/dataverse/dataverse.scss
+++ b/src/ui/page/dataverse/dataverse.scss
@@ -171,22 +171,6 @@
             grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
             gap: 29px;
           }
-
-          .okp4-dataverse-portal-dataverse-page-card-loader-container {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            width: 100%;
-            gap: 20px;
-
-            .okp4-dataverse-portal-dataverse-page-card-loader-text-wrapper {
-              width: 100%;
-              display: flex;
-              flex-direction: column;
-              align-items: center;
-              gap: 5px;
-            }
-          }
         }
       }
     }

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -18,11 +18,10 @@ import {
 import '@/ui/view/dataverse/component/filters/i18n/index'
 import './dataverse.scss'
 import { activeLanguageWithDefault } from '@/ui/languages/languages'
-import { Card } from '@/ui/component/card/card'
-import { Skeleton } from '@/ui/component/skeleton/skeleton'
 import { LottieLoader } from '@/ui/component/loader/lottieLoader'
 import threeDots from '@/ui/asset/loader/threeDots.json'
 import { useDispatchNotification } from '@/ui/hook/useDispatchNotification'
+import { loadingDataverseCards } from '@/ui/view/loadingDataverseCards/loadingDataverseCards'
 import type { ByTypeFilterInput, DataverseElementType } from '@/domain/dataverse/command'
 import { pipe } from 'fp-ts/lib/function'
 import { useNavigate } from 'react-router-dom'
@@ -594,19 +593,6 @@ const Dataverse = (): JSX.Element => {
 
   useEffect(() => setByTypeFilter('all'), [setByTypeFilter])
 
-  const loadingDataverseCards = [...Array(12)].map((_, i) => (
-    <Card key={i}>
-      <div className="okp4-dataverse-portal-dataverse-page-card-loader-container">
-        <Skeleton height={30} variant="text" width={80} />
-        <div className="okp4-dataverse-portal-dataverse-page-card-loader-text-wrapper">
-          <Skeleton height={25} variant="text" width={'84%'} />
-          <Skeleton height={25} variant="text" width={'84%'} />
-        </div>
-        <Skeleton height={40} variant="rounded" width={150} />
-      </div>
-    </Card>
-  ))
-
   return (
     <div className="okp4-dataverse-portal-dataverse-page-main">
       {(isLargeScreen || showMobileFilters) && (
@@ -648,7 +634,7 @@ const Dataverse = (): JSX.Element => {
           >
             <div className="okp4-dataverse-portal-dataverse-page-cards-container">
               {!dataverse()().length && isLoading()()
-                ? loadingDataverseCards
+                ? loadingDataverseCards(12)
                 : dataverse()().map(({ id, properties }) => {
                     const type = properties
                       .find(p => p.property === 'type')

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -25,6 +25,7 @@ import threeDots from '@/ui/asset/loader/threeDots.json'
 import { useDispatchNotification } from '@/ui/hook/useDispatchNotification'
 import type { ByTypeFilterInput, DataverseElementType } from '@/domain/dataverse/command'
 import { pipe } from 'fp-ts/lib/function'
+import { useNavigate } from 'react-router-dom'
 
 type DataverseItemType = 'service' | 'dataspace' | 'dataset'
 type FilterLabel = 'dataspaces' | 'datasets' | 'services' | 'all'
@@ -489,6 +490,8 @@ const renderMobileTitleFilters = (label: string, toggleMobileFilters: () => void
 // eslint-disable-next-line max-lines-per-function
 const Dataverse = (): JSX.Element => {
   const { t } = useTranslation('common')
+  const navigate = useNavigate()
+
   const theme = useAppStore(state => state.theme)
   const {
     loadDataverse,
@@ -538,6 +541,13 @@ const Dataverse = (): JSX.Element => {
       action: 'refresh'
     })
   }, [dispatchNotification])
+
+  const handleDataverseItemDetails = useCallback(
+    (id: string, type: DataverseItemType) => (): void => {
+      navigate(`/dataverse/${type}/${id}`)
+    },
+    [navigate]
+  )
 
   const FiltersChips = (): JSX.Element =>
     useMemo(
@@ -639,19 +649,25 @@ const Dataverse = (): JSX.Element => {
             <div className="okp4-dataverse-portal-dataverse-page-cards-container">
               {!dataverse()().length && isLoading()()
                 ? loadingDataverseCards
-                : dataverse()().map(({ id, properties }) => (
-                    <DataverseItemCard
-                      id={id}
-                      key={id}
-                      label={properties.find(p => p.property === 'title')?.value ?? ''}
-                      topic={properties.find(p => p.property === 'topic')?.value ?? ''}
-                      type={
-                        properties
-                          .find(p => p.property === 'type')
-                          ?.value.toLowerCase() as DataverseItemType
-                      }
-                    />
-                  ))}
+                : dataverse()().map(({ id, properties }) => {
+                    const type = properties
+                      .find(p => p.property === 'type')
+                      ?.value.toLowerCase() as DataverseItemType
+                    return (
+                      <DataverseItemCard
+                        button={
+                          <Button
+                            label={t('actions.details')}
+                            onClick={handleDataverseItemDetails(id, type)}
+                          />
+                        }
+                        key={id}
+                        label={properties.find(p => p.property === 'title')?.value ?? ''}
+                        topic={properties.find(p => p.property === 'topic')?.value ?? ''}
+                        type={type}
+                      />
+                    )
+                  })}
             </div>
           </InfiniteScroll>
         </div>

--- a/src/ui/page/home/explore/explore.tsx
+++ b/src/ui/page/home/explore/explore.tsx
@@ -1,13 +1,21 @@
+import { useCallback } from 'react'
 import type { FC } from 'react'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import '../i18n/index'
 import './explore.scss'
-import type { DataverseItemCardProps } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
 import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
 import { Button } from '@/ui/component/button/button'
 import { Icon } from '@/ui/component/icon/icon'
-import { NavLink } from 'react-router-dom'
 import { routes } from '@/ui/routes'
+import type { DataverseItem } from '@/ui/types'
+
+type DataverseItemCardProps = {
+  id: string
+  type: DataverseItem
+  label: string
+  topic: string
+}
 
 const exploreItems: DataverseItemCardProps[] = [
   {
@@ -38,13 +46,28 @@ const exploreItems: DataverseItemCardProps[] = [
 
 export const Explore: FC = () => {
   const { t } = useTranslation('home')
+  const navigate = useNavigate()
+
+  const handleDataverseItemDetails = useCallback(
+    (id: string, type: DataverseItem) => (): void => {
+      navigate(`/dataverse/${type}/${id}`)
+    },
+    [navigate]
+  )
 
   return (
     <>
       <h1>{t('home.blocks.explore.label')}</h1>
       {exploreItems.map(({ id, type, topic, label }) => (
         <div className="okp4-dataverse-portal-home-page-explore-card-wrapper" key={label}>
-          <DataverseItemCard id={id} label={label} topic={topic} type={type} />
+          <DataverseItemCard
+            button={
+              <Button label={t('actions.details')} onClick={handleDataverseItemDetails(id, type)} />
+            }
+            label={label}
+            topic={topic}
+            type={type}
+          />
         </div>
       ))}
       <NavLink

--- a/src/ui/page/share/dataset/shareDataset.scss
+++ b/src/ui/page/share/dataset/shareDataset.scss
@@ -1,0 +1,12 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins';
+
+.okp4-dataverse-portal-share-dataset-page-main {
+  @include with-theme {
+    h1 {
+      @include norse-gradient-header($line-height: 36px);
+      margin-bottom: 20px;
+    }
+  }
+}

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -1,0 +1,15 @@
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import '../i18n/index'
+import './shareDataset.scss'
+
+
+export const ShareDataset: FC = () => {
+  const { t } = useTranslation('share')
+
+  return (
+    <div className="okp4-dataverse-portal-share-dataset-page-main">
+      <h1>{t('share.dataset.title')}</h1>
+    </div>
+  )
+}

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -1,9 +1,8 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import { ServiceStorageSelection } from './steps/serviceStorageSelection/serviceStorageSelection'
 import '../i18n/index'
 import './shareDataset.scss'
-
-import { ServiceStorageSelection } from './steps/serviceStorageSelection/serviceStorageSelection'
 
 export const ShareDataset: FC = () => {
   const { t } = useTranslation('share')

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import '../i18n/index'
 import './shareDataset.scss'
 
+import { ServiceStorageSelection } from './steps/serviceStorageSelection/serviceStorageSelection'
 
 export const ShareDataset: FC = () => {
   const { t } = useTranslation('share')
@@ -10,6 +11,7 @@ export const ShareDataset: FC = () => {
   return (
     <div className="okp4-dataverse-portal-share-dataset-page-main">
       <h1>{t('share.dataset.title')}</h1>
+      <ServiceStorageSelection />
     </div>
   )
 }

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
@@ -7,7 +7,7 @@
     @include grid-container($colGutter: 10px, $rowGutter: 22px);
 
     h2 {
-      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
       @include noto-sans(700);
       font-size: 28px;
       line-height: 28px;
@@ -16,7 +16,8 @@
     }
 
     .okp4-dataverse-portal-share-dataset-page-service-selection-tabs {
-      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: 2);
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
+
       h3 {
         @include noto-sans(700);
         font-size: 16px;
@@ -28,11 +29,11 @@
     }
 
     .okp4-dataverse-portal-searchbar-main {
-      @include grid-item($colStart: 1, $colEnd: 7, $rowStart: 3, $rowEnd: 3);
+      @include grid-item($colStart: 1, $colEnd: 7, $rowStart: auto, $rowEnd: auto);
     }
 
     .okp4-dataverse-portal-share-dataset-page-services-container {
-      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 4, $rowEnd: auto);
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: auto, $rowEnd: auto);
       max-height: 610px;
       overflow-y: auto;
 
@@ -46,16 +47,3 @@
     }
   }
 }
-
-// .okp4-dataverse-portal-share-dataset-page-services {
-//   @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 4, $rowEnd: auto);
-//   max-height: 610px;
-//   overflow-y: auto;
-
-//   div {
-//     display: grid;
-//     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-//     gap: 48px;
-//     margin-right: 15px;
-//   }
-// }

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
@@ -1,0 +1,61 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-share-dataset-page-service-selection-container {
+  @include with-theme() {
+    @include grid-container($colGutter: 10px, $rowGutter: 22px);
+
+    h2 {
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 1, $rowEnd: 1);
+      @include noto-sans(700);
+      font-size: 28px;
+      line-height: 28px;
+      letter-spacing: 0.4px;
+      color: themed('text');
+    }
+
+    .okp4-dataverse-portal-share-dataset-page-service-selection-tabs {
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 2, $rowEnd: 2);
+      h3 {
+        @include noto-sans(700);
+        font-size: 16px;
+        line-height: 24px;
+        letter-spacing: 0.4px;
+        color: themed('text');
+        margin-bottom: 16px;
+      }
+    }
+
+    .okp4-dataverse-portal-searchbar-main {
+      @include grid-item($colStart: 1, $colEnd: 7, $rowStart: 3, $rowEnd: 3);
+    }
+
+    .okp4-dataverse-portal-share-dataset-page-services-container {
+      @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 4, $rowEnd: auto);
+      max-height: 610px;
+      overflow-y: auto;
+
+      .okp4-dataverse-portal-share-dataset-page-services {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        grid-auto-rows: 220px;
+        gap: 48px;
+        margin-right: 15px;
+      }
+    }
+  }
+}
+
+// .okp4-dataverse-portal-share-dataset-page-services {
+//   @include grid-item($colStart: 1, $colEnd: -1, $rowStart: 4, $rowEnd: auto);
+//   max-height: 610px;
+//   overflow-y: auto;
+
+//   div {
+//     display: grid;
+//     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+//     gap: 48px;
+//     margin-right: 15px;
+//   }
+// }

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useEffect } from 'react'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { SearchBar } from '@/ui/component/searchbar/searchbar'
+import { useDataverseStore } from '@/ui/store'
+import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
+import { Button } from '@/ui/component/button/button'
+import { loadingDataverseCards } from '@/ui/view/loadingDataverseCards/loadingDataverseCards'
+import type { DataverseItem } from '@/ui/types'
+import { activeLanguageWithDefault } from '@/ui/languages/languages'
+import '../../../i18n/index'
+import './serviceStorageSelection.scss'
+
+// eslint-disable-next-line max-lines-per-function
+export const ServiceStorageSelection: FC = () => {
+  const { t } = useTranslation(['common', 'share', 'publisher'])
+  const currentLng = activeLanguageWithDefault().lng
+
+  const { loadDataverse, dataverse, setByTypeFilter, isLoading, setLanguage } = useDataverseStore(
+    state => ({
+      loadDataverse: state.loadDataverse,
+      dataverse: state.dataverse,
+      isLoading: state.isLoading,
+      hasNext: state.hasNext,
+      setLanguage: state.setLanguage,
+      setByTypeFilter: state.setByTypeFilter
+    })
+  )
+  const handleServiceSearch = useCallback((searchTearm: string) => {
+    console.log(searchTearm)
+  }, [])
+
+  const handleSelect = useCallback(
+    (id: string) => () => {
+      console.log(id)
+    },
+    []
+  )
+
+  useEffect(() => {
+    setLanguage(currentLng)()
+    setByTypeFilter('Service')()
+    loadDataverse()()
+    return () => setByTypeFilter('all')()
+  }, [currentLng, loadDataverse, setByTypeFilter, setLanguage])
+
+  return (
+    <div className="okp4-dataverse-portal-share-dataset-page-service-selection-container">
+      <h2>{t('share:share.dataset.selectStorage')}</h2>
+      <div className="okp4-dataverse-portal-share-dataset-page-service-selection-tabs">
+        <h3>{t('share:share.dataset.location')}</h3>
+        <div>tabs</div>
+      </div>
+      <SearchBar
+        onSearch={handleServiceSearch}
+        placeholder={t('share:share.dataset.serviceStorageSearch')}
+        value=""
+      />
+      <div className="okp4-dataverse-portal-share-dataset-page-services-container">
+        <div className="okp4-dataverse-portal-share-dataset-page-services">
+          {!dataverse()().length && isLoading()()
+            ? loadingDataverseCards(12)
+            : dataverse()().map(({ id, properties }) => {
+                const publisher = properties.find(p => p.property === 'publisher')?.value ?? ''
+                const publisherDescription = `${t('metadata:publisher')} **${publisher}**`
+                return (
+                  <DataverseItemCard
+                    button={<Button label={t('select')} onClick={handleSelect(id)} />}
+                    key={id}
+                    label={properties.find(p => p.property === 'title')?.value ?? ''}
+                    topic={publisherDescription}
+                    type={
+                      properties
+                        .find(p => p.property === 'type')
+                        ?.value.toLowerCase() as DataverseItem
+                    }
+                  />
+                )
+              })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import InfiniteScroll from 'react-infinite-scroll-component'
@@ -7,16 +7,19 @@ import { useDataverseStore } from '@/ui/store'
 import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
 import { Button } from '@/ui/component/button/button'
 import { loadingDataverseCards } from '@/ui/view/loadingDataverseCards/loadingDataverseCards'
+import type { Tab } from '@/ui/view/tabs/tabs'
+import { Tabs } from '@/ui/view/tabs/tabs'
 import type { DataverseItem } from '@/ui/types'
 import { activeLanguageWithDefault } from '@/ui/languages/languages'
 import { LottieLoader } from '@/ui/component/loader/lottieLoader'
 import threeDots from '@/ui/asset/loader/threeDots.json'
-import '../../../i18n/index'
+import '@/ui/page/share/i18n/index'
 import './serviceStorageSelection.scss'
 
 // eslint-disable-next-line max-lines-per-function
 export const ServiceStorageSelection: FC = () => {
   const { t } = useTranslation(['common', 'share', 'publisher'])
+  const [activeTab, setActiveTab] = useState<Tab>('left')
   const currentLng = activeLanguageWithDefault().lng
 
   const { loadDataverse, dataverse, setByTypeFilter, isLoading, hasNext, setLanguage } =
@@ -52,7 +55,13 @@ export const ServiceStorageSelection: FC = () => {
       <h2>{t('share:share.dataset.selectStorage')}</h2>
       <div className="okp4-dataverse-portal-share-dataset-page-service-selection-tabs">
         <h3>{t('share:share.dataset.location')}</h3>
-        <div>tabs</div>
+        <Tabs
+          activeTab={activeTab}
+          disabledTab="right"
+          handleTabChange={setActiveTab}
+          leftTabLabel={t('share:share.dataset.local')}
+          rightTabLabel={t('share:share.dataset.external')}
+        />
       </div>
       <SearchBar
         onSearch={handleServiceSearch}

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import InfiniteScroll from 'react-infinite-scroll-component'
 import { SearchBar } from '@/ui/component/searchbar/searchbar'
 import { useDataverseStore } from '@/ui/store'
 import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
@@ -8,6 +9,8 @@ import { Button } from '@/ui/component/button/button'
 import { loadingDataverseCards } from '@/ui/view/loadingDataverseCards/loadingDataverseCards'
 import type { DataverseItem } from '@/ui/types'
 import { activeLanguageWithDefault } from '@/ui/languages/languages'
+import { LottieLoader } from '@/ui/component/loader/lottieLoader'
+import threeDots from '@/ui/asset/loader/threeDots.json'
 import '../../../i18n/index'
 import './serviceStorageSelection.scss'
 
@@ -16,16 +19,16 @@ export const ServiceStorageSelection: FC = () => {
   const { t } = useTranslation(['common', 'share', 'publisher'])
   const currentLng = activeLanguageWithDefault().lng
 
-  const { loadDataverse, dataverse, setByTypeFilter, isLoading, setLanguage } = useDataverseStore(
-    state => ({
+  const { loadDataverse, dataverse, setByTypeFilter, isLoading, hasNext, setLanguage } =
+    useDataverseStore(state => ({
       loadDataverse: state.loadDataverse,
       dataverse: state.dataverse,
       isLoading: state.isLoading,
       hasNext: state.hasNext,
       setLanguage: state.setLanguage,
       setByTypeFilter: state.setByTypeFilter
-    })
-  )
+    }))
+
   const handleServiceSearch = useCallback((searchTearm: string) => {
     console.log(searchTearm)
   }, [])
@@ -56,28 +59,40 @@ export const ServiceStorageSelection: FC = () => {
         placeholder={t('share:share.dataset.serviceStorageSearch')}
         value=""
       />
-      <div className="okp4-dataverse-portal-share-dataset-page-services-container">
-        <div className="okp4-dataverse-portal-share-dataset-page-services">
-          {!dataverse()().length && isLoading()()
-            ? loadingDataverseCards(12)
-            : dataverse()().map(({ id, properties }) => {
-                const publisher = properties.find(p => p.property === 'publisher')?.value ?? ''
-                const publisherDescription = `${t('metadata:publisher')} **${publisher}**`
-                return (
-                  <DataverseItemCard
-                    button={<Button label={t('select')} onClick={handleSelect(id)} />}
-                    key={id}
-                    label={properties.find(p => p.property === 'title')?.value ?? ''}
-                    topic={publisherDescription}
-                    type={
-                      properties
-                        .find(p => p.property === 'type')
-                        ?.value.toLowerCase() as DataverseItem
-                    }
-                  />
-                )
-              })}
-        </div>
+      <div
+        className="okp4-dataverse-portal-share-dataset-page-services-container"
+        id="scrollable-container"
+      >
+        <InfiniteScroll
+          dataLength={dataverse()().length}
+          hasMore={hasNext()()}
+          loader={dataverse()().length && <LottieLoader animationData={threeDots} />}
+          next={loadDataverse()}
+          scrollThreshold={0.91}
+          scrollableTarget="scrollable-container"
+        >
+          <div className="okp4-dataverse-portal-share-dataset-page-services">
+            {!dataverse()().length && isLoading()()
+              ? loadingDataverseCards(12)
+              : dataverse()().map(({ id, properties }) => {
+                  const publisher = properties.find(p => p.property === 'publisher')?.value ?? ''
+                  const publisherDescription = `${t('metadata:publisher')} **${publisher}**`
+                  return (
+                    <DataverseItemCard
+                      button={<Button label={t('select')} onClick={handleSelect(id)} />}
+                      key={id}
+                      label={properties.find(p => p.property === 'title')?.value ?? ''}
+                      topic={publisherDescription}
+                      type={
+                        properties
+                          .find(p => p.property === 'type')
+                          ?.value.toLowerCase() as DataverseItem
+                      }
+                    />
+                  )
+                })}
+          </div>
+        </InfiniteScroll>
       </div>
     </div>
   )

--- a/src/ui/page/share/i18n/share_de.json
+++ b/src/ui/page/share/i18n/share_de.json
@@ -2,7 +2,10 @@
   "share": {
     "dataset": {
       "title": "Ich teile einen Datensatz",
-      "description": "Einfaches Freigeben Ihres Datensatzes im Dataverse"
+      "description": "Einfaches Freigeben Ihres Datensatzes im Dataverse",
+      "selectStorage": "Wählen Sie einen Speicherdienst",
+      "location": "Mein Datensatz befindet sich in",
+      "serviceStorageSearch": "Suche nach einem Speicherdienst"
     },
     "service": {
       "title": "Ich teile einen Dienst",

--- a/src/ui/page/share/i18n/share_de.json
+++ b/src/ui/page/share/i18n/share_de.json
@@ -5,6 +5,8 @@
       "description": "Einfaches Freigeben Ihres Datensatzes im Dataverse",
       "selectStorage": "Wählen Sie einen Speicherdienst",
       "location": "Mein Datensatz befindet sich in",
+      "local": "Einem lokalen Ordner",
+      "external": "Ein externer Speicher",
       "serviceStorageSearch": "Suche nach einem Speicherdienst"
     },
     "service": {

--- a/src/ui/page/share/i18n/share_en.json
+++ b/src/ui/page/share/i18n/share_en.json
@@ -5,6 +5,8 @@
       "description": "Easily share your dataset in the dataverse",
       "selectStorage": "Select a Storage Service",
       "location": "My dataset is in",
+      "local": "A local folder",
+      "external": "An external storage",
       "serviceStorageSearch": "Search a storage service"
     },
     "service": {

--- a/src/ui/page/share/i18n/share_en.json
+++ b/src/ui/page/share/i18n/share_en.json
@@ -2,7 +2,10 @@
   "share": {
     "dataset": {
       "title": "I share a dataset",
-      "description": "Easily share your dataset in the dataverse"
+      "description": "Easily share your dataset in the dataverse",
+      "selectStorage": "Select a Storage Service",
+      "location": "My dataset is in",
+      "serviceStorageSearch": "Search a storage service"
     },
     "service": {
       "title": "I share a service",

--- a/src/ui/page/share/i18n/share_fr.json
+++ b/src/ui/page/share/i18n/share_fr.json
@@ -2,7 +2,10 @@
   "share": {
     "dataset": {
       "title": "Je partage un jeu de données",
-      "description": "Partagez facilement votre jeu de données dans le dataverse"
+      "description": "Partagez facilement votre jeu de données dans le dataverse",
+      "selectStorage": "Sélectionner un Service de Stockage",
+      "location": "Mon jeu de données se trouve dans",
+      "serviceStorageSearch": "Rechercher un service de stockage"
     },
     "service": {
       "title": "Je partage un service",

--- a/src/ui/page/share/i18n/share_fr.json
+++ b/src/ui/page/share/i18n/share_fr.json
@@ -5,6 +5,8 @@
       "description": "Partagez facilement votre jeu de données dans le dataverse",
       "selectStorage": "Sélectionner un Service de Stockage",
       "location": "Mon jeu de données se trouve dans",
+      "local": "Un dossier local",
+      "external": "Un stockage externe",
       "serviceStorageSearch": "Rechercher un service de stockage"
     },
     "service": {

--- a/src/ui/page/share/share.scss
+++ b/src/ui/page/share/share.scss
@@ -32,6 +32,7 @@
 
       &.left {
         @include bi-column-item('left');
+        cursor: pointer;
 
         .okp4-dataverse-portal-share-page-ilustration {
           background: center / contain url('@/ui/asset/images/share-dataset.webp') no-repeat;

--- a/src/ui/page/share/share.tsx
+++ b/src/ui/page/share/share.tsx
@@ -11,16 +11,13 @@ export const Share: FC = () => {
   const { t } = useTranslation('share')
   const navigate = useNavigate()
 
-  const navigateToShareDataset = useCallback(() => {
+  const handleShareDataset = useCallback(() => {
     navigate(routes.shareDataset)
   }, [navigate])
 
   return (
     <div className="okp4-dataverse-portal-share-page-main">
-      <Card
-        mainClassName="okp4-dataverse-portal-share-page-card left"
-        onClick={navigateToShareDataset}
-      >
+      <Card mainClassName="okp4-dataverse-portal-share-page-card left" onClick={handleShareDataset}>
         <>
           <div className="okp4-dataverse-portal-share-page-ilustration" />
           <div className="okp4-dataverse-portal-share-page-text-container">

--- a/src/ui/page/share/share.tsx
+++ b/src/ui/page/share/share.tsx
@@ -1,15 +1,26 @@
 import type { FC } from 'react'
-import { Card } from '@/ui/component/card/card'
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { Card } from '@/ui/component/card/card'
+import { routes } from '@/ui/routes'
 import './share.scss'
 import './i18n/index'
 
 export const Share: FC = () => {
   const { t } = useTranslation('share')
+  const navigate = useNavigate()
+
+  const navigateToShareDataset = useCallback(() => {
+    navigate(routes.shareDataset)
+  }, [navigate])
 
   return (
     <div className="okp4-dataverse-portal-share-page-main">
-      <Card mainClassName="okp4-dataverse-portal-share-page-card left">
+      <Card
+        mainClassName="okp4-dataverse-portal-share-page-card left"
+        onClick={navigateToShareDataset}
+      >
         <>
           <div className="okp4-dataverse-portal-share-page-ilustration" />
           <div className="okp4-dataverse-portal-share-page-text-container">

--- a/src/ui/routes.tsx
+++ b/src/ui/routes.tsx
@@ -5,7 +5,8 @@ import Dataset from '@/ui/page/dataverse/dataset/dataset'
 import Service from '@/ui/page/dataverse/service/service'
 import { Governance } from '@/ui/page/dataverse/dataspace/governance/governance'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
-import { Share } from './page/share/share'
+import { Share } from '@/ui/page/share/share'
+import { ShareDataset } from '@/ui/page/share/dataset/shareDataset'
 
 export enum routes {
   home = '/',
@@ -15,6 +16,7 @@ export enum routes {
   service = 'dataverse/service/:id',
   governance = 'dataverse/dataspace/:id/governance/:sectionId?/:subsectionId?',
   share = 'share',
+  shareDataset = '/share/data',
   notFoundError = '*'
 }
 
@@ -64,5 +66,10 @@ export const appRoutes: Route[] = [
     id: 'share',
     path: routes.share,
     element: <Share />
+  },
+  {
+    id: 'shareDataset',
+    path: routes.shareDataset,
+    element: <ShareDataset />
   }
 ]

--- a/src/ui/style/palette.scss
+++ b/src/ui/style/palette.scss
@@ -92,3 +92,12 @@ $paragraph-background-light: #dfe4e9;
 
 // checkbox
 $disabled-checkbox-background: #e5ebf0;
+
+//tabs
+$tab-disabled-background: #b2c3d1;
+$tab-disabled-text: #94a2ae;
+$tab-inactive-background-light: rgba(0, 64, 115, 0.06);
+$tab-inactive-background-dark: rgba(255, 255, 255, 0.06);
+$tab-inactive-text-light: rgba(0, 64, 115, 0.6);
+$tab-inactive-text-dark: rgba(255, 255, 255, 0.6);
+$tab-active-background: #004073;

--- a/src/ui/style/theme.scss
+++ b/src/ui/style/theme.scss
@@ -49,7 +49,12 @@ $themes: (
     disabled-checkbox-background: $disabled-checkbox-background,
     drop-down-menu-menu-background: $text-dark,
     drop-down-menu-selected-background: $background-light-variant-1,
-    drop-down-menu-selected-border: rgba($primary-variant-1, 0.12)
+    drop-down-menu-selected-border: rgba($primary-variant-1, 0.12),
+    tab-active-background: $tab-active-background,
+    tab-disabled-background: $tab-disabled-background,
+    tab-disabled-text: $tab-disabled-text,
+    tab-inactive-background: $tab-inactive-background-light,
+    tab-inactive-text: $tab-inactive-text-light
   ),
   dark: (
     primary-color: $primary,
@@ -98,7 +103,12 @@ $themes: (
     disabled-checkbox-background: $disabled-checkbox-background,
     drop-down-menu-menu-background: $card-dark,
     drop-down-menu-selected-background: $card-dark,
-    drop-down-menu-selected-border: transparent
+    drop-down-menu-selected-border: transparent,
+    tab-active-background: $tab-active-background,
+    tab-disabled-background: $tab-disabled-background,
+    tab-disabled-text: $tab-disabled-text,
+    tab-inactive-background: $tab-inactive-background-dark,
+    tab-inactive-text: $tab-inactive-text-dark
   )
 );
 

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,0 +1,1 @@
+export type DataverseItem = 'dataspace' | 'dataset' | 'service'

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -3,12 +3,12 @@ import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { Card } from '@/ui/component/card/card'
+import type { DataverseItem } from '@/ui/types'
 import { Button } from '@/ui/component/button/button'
 import './dataverseItemCard.scss'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 
-type DataverseItem = 'dataspace' | 'dataset' | 'service'
 
 export type DataverseItemCardProps = {
   id: string

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -1,24 +1,20 @@
 import type { FC } from 'react'
 import { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import { Card } from '@/ui/component/card/card'
 import type { DataverseItem } from '@/ui/types'
-import { Button } from '@/ui/component/button/button'
 import './dataverseItemCard.scss'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 
-
 export type DataverseItemCardProps = {
-  id: string
   type: DataverseItem
   label: string
   topic: string
+  button: JSX.Element
 }
 
-export const DataverseItemCard: FC<DataverseItemCardProps> = ({ id, type, label, topic }) => {
-  const navigate = useNavigate()
+export const DataverseItemCard: FC<DataverseItemCardProps> = ({ type, label, topic, button }) => {
   const { t } = useTranslation('common')
 
   type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
@@ -40,10 +36,6 @@ ${topic}`,
     []
   )
 
-  const handleDataverseItemDetails = useCallback((): void => {
-    navigate(`/dataverse/${type}/${id}`)
-  }, [id, navigate, type])
-
   return (
     <Card>
       <div className="okp4-dataverse-portal-dataverse-card-main">
@@ -59,7 +51,7 @@ ${topic}`,
           <div className="okp4-dataverse-portal-dataverse-topic">
             <ReactMarkdown>{renderItemContent(label, topic)}</ReactMarkdown>
           </div>
-          <Button label={t('actions.details')} onClick={handleDataverseItemDetails} />
+          {button}
         </div>
       </div>
     </Card>

--- a/src/ui/view/dataverse/component/itemOverview/itemOverview.tsx
+++ b/src/ui/view/dataverse/component/itemOverview/itemOverview.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import { Tags } from '@/ui/view/dataverse/component//tags/tags'
+import type { DataverseItem } from '@/ui/types'
 import './itemOverview.scss'
 
 type ItemOverviewProps = {
@@ -11,7 +12,6 @@ type ItemOverviewProps = {
   description: string
   tags: string[]
 }
-type DataverseItem = 'dataspace' | 'dataset' | 'service'
 type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
 
 const ItemOverview: FC<ItemOverviewProps> = ({ type, title, description, tags }): JSX.Element => {

--- a/src/ui/view/loadingDataverseCards/loadingDataverseCards.scss
+++ b/src/ui/view/loadingDataverseCards/loadingDataverseCards.scss
@@ -1,0 +1,13 @@
+@import '@/ui/style/mixins';
+
+.okp4-dataverse-portal-card-loader-container {
+  @include columns-with-gap(20px);
+  align-items: center;
+  width: 100%;
+
+  .okp4-dataverse-portal-card-loader-text-wrapper {
+    @include columns-with-gap(5px);
+    width: 100%;
+    align-items: center;
+  }
+}

--- a/src/ui/view/loadingDataverseCards/loadingDataverseCards.tsx
+++ b/src/ui/view/loadingDataverseCards/loadingDataverseCards.tsx
@@ -1,0 +1,17 @@
+import { Card } from '@/ui/component/card/card'
+import { Skeleton } from '@/ui/component/skeleton/skeleton'
+import './loadingDataverseCards.scss'
+
+export const loadingDataverseCards = (quantity: number): JSX.Element[] =>
+  [...Array(quantity)].map((_, i) => (
+    <Card key={i}>
+      <div className="okp4-dataverse-portal-card-loader-container">
+        <Skeleton height={30} variant="text" width={80} />
+        <div className="okp4-dataverse-portal-card-loader-text-wrapper">
+          <Skeleton height={25} variant="text" width={'84%'} />
+          <Skeleton height={25} variant="text" width={'84%'} />
+        </div>
+        <Skeleton height={40} variant="rounded" width={150} />
+      </div>
+    </Card>
+  ))

--- a/src/ui/view/tabs/tabs.scss
+++ b/src/ui/view/tabs/tabs.scss
@@ -1,0 +1,37 @@
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-tabs-main {
+  @include with-theme() {
+    display: flex;
+    background-color: themed('tab-inactive-background');
+    width: fit-content;
+    border-radius: 12px;
+
+    &.disabled {
+      background-color: themed('tab-disabled-background');
+    }
+
+    @include noto-sans(700);
+    line-height: 20px;
+
+    .okp4-dataverse-portal-tab {
+      border-radius: 12px;
+      padding: 12px 20px;
+      color: themed('tab-inactive-text');
+      cursor: pointer;
+
+      &.disabled {
+        background-color: themed('tab-disabled-background');
+        color: themed('tab-disabled-text');
+        cursor: not-allowed;
+      }
+
+      &.active {
+        background-color: themed('tab-active-background');
+        color: themed('primary-text');
+      }
+    }
+  }
+}

--- a/src/ui/view/tabs/tabs.tsx
+++ b/src/ui/view/tabs/tabs.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react'
+import type { FC } from 'react'
+import classNames from 'classnames'
+import './tabs.scss'
+
+export type Tab = 'left' | 'right'
+
+type TabsProps = {
+  activeTab: Tab
+  leftTabLabel: string
+  rightTabLabel: string
+  handleTabChange: (tab: Tab) => void
+  disabledTab?: Tab
+}
+
+export const Tabs: FC<TabsProps> = ({
+  activeTab,
+  leftTabLabel,
+  rightTabLabel,
+  handleTabChange,
+  disabledTab
+}) => {
+  const tabs: [Tab, Tab] = ['left', 'right']
+
+  const handleTabSelection = useCallback(
+    (tab: Tab) => () => {
+      activeTab === tab && handleTabChange(tab)
+    },
+    [activeTab, handleTabChange]
+  )
+
+  return (
+    <div
+      className={classNames('okp4-dataverse-portal-tabs-main', {
+        disabled: !!disabledTab
+      })}
+    >
+      {tabs.map((tab: Tab) => (
+        <div
+          className={classNames('okp4-dataverse-portal-tab', {
+            disabled: disabledTab === tab,
+            active: activeTab === tab
+          })}
+          key={tab}
+          onClick={handleTabSelection(tab)}
+        >
+          {tab === 'left' ? leftTabLabel : rightTabLabel}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
This Pr implements the UI part of the share dataset page [1st step](https://github.com/okp4/dataverse-portal/issues/235).

All that remains is to modify the scrollbar color, which will be implemented at a later date to take advantage of Loïc's mixin, which is contained in another PR.
The `Tabs` component has been coded to contain only 2 tabs (it has not been designed to contain more), which is why it has been integrated into the `views` folder (to be shared in the `dataverse`) and not in the `components` folder, which is supposed to contain generic elements.