### PR TITLE
build(scss): integrate autoprefixer and remove manual vendor prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.59.9",
     "@vitejs/plugin-react-swc": "^3.3.2",
+    "autoprefixer": "^10.4.14",
     "classnames": "^2.3.2",
     "eslint": "^8.42.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ devDependencies:
   '@vitejs/plugin-react-swc':
     specifier: ^3.3.2
     version: 3.3.2(vite@4.3.9)
+  autoprefixer:
+    specifier: ^10.4.14
+    version: 10.4.14(postcss@8.4.24)
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
@@ -2373,6 +2376,22 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /autoprefixer@10.4.14(postcss@8.4.24):
+    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.21.5
+      caniuse-lite: 1.0.30001502
+      fraction.js: 4.2.0
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.24
+      postcss-value-parser: 4.2.0
+    dev: true
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
@@ -2505,7 +2524,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001453
+      caniuse-lite: 1.0.30001502
       electron-to-chromium: 1.4.299
       node-releases: 2.0.10
       update-browserslist-db: 1.0.10(browserslist@4.21.5)
@@ -2559,8 +2578,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001453:
-    resolution: {integrity: sha512-R9o/uySW38VViaTrOtwfbFEiBFUh7ST3uIG4OEymIG3/uKdHDO4xk/FaqfUw0d+irSUyFPy3dZszf9VvSTPnsA==}
+  /caniuse-lite@1.0.30001502:
+    resolution: {integrity: sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==}
     dev: true
 
   /chalk@2.4.2:
@@ -3424,6 +3443,10 @@ packages:
   /fp-ts@2.15.0:
     resolution: {integrity: sha512-3o6EllAvGuCsDgjM+frscLKDRPR9pqbrg13tJ13z86F4eni913kBV8h85rM6zpu2fEvJ8RWA0ouYlUWwHEmxTg==}
     dev: false
+
+  /fraction.js@4.2.0:
+    resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
+    dev: true
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -4978,6 +5001,11 @@ packages:
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
     dev: true
 

--- a/src/ui/component/dropDown/dropDown.scss
+++ b/src/ui/component/dropDown/dropDown.scss
@@ -9,8 +9,6 @@
       height: 100%;
       width: 100%;
       backdrop-filter: blur(1px);
-      /* stylelint-disable-next-line property-no-vendor-prefix */
-      -webkit-backdrop-filter: blur(1px);
       z-index: 100;
     }
 
@@ -29,11 +27,6 @@
         cursor: pointer;
         border-radius: 6px;
         user-select: none;
-        /* stylelint-disable property-no-vendor-prefix */
-        -webkit-user-select: none;
-        -ms-user-select: none;
-        -moz-user-select: none;
-        /* stylelint-enable property-no-vendor-prefix */
 
         &.selected {
           @include noto-sans(400);

--- a/src/ui/component/searchbar/searchbar.scss
+++ b/src/ui/component/searchbar/searchbar.scss
@@ -49,8 +49,7 @@
       &::-webkit-search-decoration,
       &::-webkit-search-results-button,
       &::-webkit-search-results-decoration {
-        /* stylelint-disable-next-line property-no-vendor-prefix */
-        -webkit-appearance:none;
+        appearance:none;
       }
     }
   }

--- a/src/ui/style/mixins.scss
+++ b/src/ui/style/mixins.scss
@@ -98,8 +98,7 @@
   letter-spacing: 4px;
   font-size: 24px;
   background: themed('gradient');
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,18 @@ import react from '@vitejs/plugin-react-swc'
 import svgr from 'vite-plugin-svgr'
 import path from 'path'
 import htmlConfig from 'vite-plugin-html-config'
+import autoprefixer from 'autoprefixer'
 
 import htmlConfigOptions from './config/html-config'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   plugins: [htmlConfig(htmlConfigOptions), react(), svgr()],
+  css: {
+    postcss: {
+      plugins: [autoprefixer({})]
+    }
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')


### PR DESCRIPTION
Following [this discussion](https://github.com/okp4/dataverse-portal/discussions/253), this PR integrates the [autoprefixer](https://www.npmjs.com/package/autoprefixer) plugin into our Vite configuration to automate vendor prefixing in the stylesheets, enhancing cross-browser compatibility.