### PR TITLE
Feat: share dataset service selection

### DIFF
--- a/src/ui/common.ts
+++ b/src/ui/common.ts
@@ -1,0 +1,12 @@
+import type { ColorVariant, DataverseItem } from './types'
+
+export const renderItemTypeColor = (type: DataverseItem): ColorVariant => {
+  switch (type) {
+    case 'service':
+      return 'primary-color'
+    case 'dataspace':
+      return 'primary-color-variant-3'
+    case 'dataset':
+      return 'primary-color-variant-4'
+  }
+}

--- a/src/ui/page/dataverse/dataverse.tsx
+++ b/src/ui/page/dataverse/dataverse.tsx
@@ -92,7 +92,7 @@ const dataverseFilters: Filter[] = [
   }
 ]
 
-const dataverseItems: DataverseItemDetails[] = [
+export const dataverseItems: DataverseItemDetails[] = [
   {
     id: 'ef347285-e52a-430d-9679-dcb76b962ce7',
     type: 'dataspace',

--- a/src/ui/page/dataverse/service/service.tsx
+++ b/src/ui/page/dataverse/service/service.tsx
@@ -8,7 +8,7 @@ import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
 import PageTemplate from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
 
-const serviceGeneralMetadata: ItemGeneralMetadata[] = [
+export const serviceGeneralMetadata: ItemGeneralMetadata[] = [
   {
     category: 'generalMetadata',
     property: 'category',
@@ -66,7 +66,7 @@ const serviceGeneralMetadata: ItemGeneralMetadata[] = [
   }
 ]
 
-const isService = (resource: DataverseItemDetails): resource is Service =>
+export const isService = (resource: DataverseItemDetails): resource is Service =>
   resource.type === 'service'
 
 const Service: FC = () => {

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.scss
@@ -37,12 +37,48 @@
       max-height: 610px;
       overflow-y: auto;
 
+      &.detailed {
+        @include bi-column-item(left);
+      }
+
       .okp4-dataverse-portal-share-dataset-page-services {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
         grid-auto-rows: 220px;
         gap: 48px;
         margin-right: 15px;
+
+        .okp4-dataverse-portal-share-dataset-page-service {
+          :focus-visible {
+            outline: none;
+          }
+
+          &.selected {
+            outline-offset: -2px;
+            outline: 2px solid themed('primary-color');
+            background-color: themed('card-background-selected');
+          }
+
+          .selected-button {
+            background-color: themed('card-button-selected');
+            box-shadow: none;
+          }
+        }
+      }
+    }
+
+    .okp4-dataverse-portal-share-dataset-page-service-details-container {
+      @include bi-column-item(right);
+      border-radius: 12px;
+      padding: 22px 22px 0;
+      background: themed('card-background-gradient');
+      margin-left: 18px;
+
+      .okp4-dataverse-portal-share-dataset-page-service-details-scroll-container {
+        max-height: 588px;
+        height: 100%;
+        padding-right: 20px;
+        overflow-y: auto;
       }
     }
   }

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useRef, useCallback, useEffect, useState } from 'react'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import classNames from 'classnames'
 import { SearchBar } from '@/ui/component/searchbar/searchbar'
 import { useDataverseStore } from '@/ui/store'
 import { DataverseItemCard } from '@/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard'
@@ -13,14 +14,24 @@ import type { DataverseItem } from '@/ui/types'
 import { activeLanguageWithDefault } from '@/ui/languages/languages'
 import { LottieLoader } from '@/ui/component/loader/lottieLoader'
 import threeDots from '@/ui/asset/loader/threeDots.json'
+import { isService, serviceGeneralMetadata } from '@/ui/page/dataverse/service/service'
+import { DetailedDataverseItem } from '@/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem'
+import { dataverseItems } from '@/ui/page/dataverse/dataverse'
+import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import { useOnKeyboard } from '@/ui/hook/useOnKeyboard'
 import '@/ui/page/share/i18n/index'
 import './serviceStorageSelection.scss'
+
+export const getResourceDetails = (id: string): DataverseItemDetails | undefined =>
+  dataverseItems.find(dataverseItem => dataverseItem.id === id)
 
 // eslint-disable-next-line max-lines-per-function
 export const ServiceStorageSelection: FC = () => {
   const { t } = useTranslation(['common', 'share', 'publisher'])
   const [activeTab, setActiveTab] = useState<Tab>('left')
+  const [selectedService, setSelectedService] = useState<DataverseItemDetails | null>(null)
   const currentLng = activeLanguageWithDefault().lng
+  const selectedServiceRef = useRef<HTMLDivElement | null>(null)
 
   const { loadDataverse, dataverse, setByTypeFilter, isLoading, hasNext, setLanguage } =
     useDataverseStore(state => ({
@@ -38,10 +49,35 @@ export const ServiceStorageSelection: FC = () => {
 
   const handleSelect = useCallback(
     (id: string) => () => {
-      console.log(id)
+      const resourceDetails = getResourceDetails(id)
+
+      if (resourceDetails && isService(resourceDetails)) {
+        setSelectedService(resourceDetails)
+      }
     },
     []
   )
+
+  const handleClose = useCallback(() => {
+    setSelectedService(null)
+  }, [])
+
+  const handleDetailsEscape = useCallback(
+    (event: KeyboardEvent) => {
+      event.key === 'Escape' && handleClose()
+    },
+    [handleClose]
+  )
+
+  useOnKeyboard(handleDetailsEscape)
+
+  useEffect(() => {
+    if (selectedService)
+      selectedServiceRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+      })
+  }, [selectedService])
 
   useEffect(() => {
     setLanguage(currentLng)()
@@ -69,7 +105,9 @@ export const ServiceStorageSelection: FC = () => {
         value=""
       />
       <div
-        className="okp4-dataverse-portal-share-dataset-page-services-container"
+        className={classNames('okp4-dataverse-portal-share-dataset-page-services-container', {
+          detailed: !!selectedService
+        })}
         id="scrollable-container"
       >
         <InfiniteScroll
@@ -86,11 +124,22 @@ export const ServiceStorageSelection: FC = () => {
               : dataverse()().map(({ id, properties }) => {
                   const publisher = properties.find(p => p.property === 'publisher')?.value ?? ''
                   const publisherDescription = `${t('metadata:publisher')} **${publisher}**`
+                  const isServiceSelected = selectedService?.id === id
                   return (
                     <DataverseItemCard
-                      button={<Button label={t('select')} onClick={handleSelect(id)} />}
+                      button={
+                        <Button
+                          className={classNames({ 'selected-button': isServiceSelected })}
+                          label={t(isServiceSelected ? 'selected' : 'select')}
+                          onClick={handleSelect(id)}
+                        />
+                      }
+                      className={classNames('okp4-dataverse-portal-share-dataset-page-service', {
+                        selected: isServiceSelected
+                      })}
                       key={id}
                       label={properties.find(p => p.property === 'title')?.value ?? ''}
+                      ref={isServiceSelected ? selectedServiceRef : undefined}
                       topic={publisherDescription}
                       type={
                         properties
@@ -103,6 +152,17 @@ export const ServiceStorageSelection: FC = () => {
           </div>
         </InfiniteScroll>
       </div>
+      {!!selectedService && (
+        <div className="okp4-dataverse-portal-share-dataset-page-service-details-container">
+          <div className="okp4-dataverse-portal-share-dataset-page-service-details-scroll-container">
+            <DetailedDataverseItem
+              data={selectedService}
+              metadata={serviceGeneralMetadata}
+              onClose={handleClose}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/ui/style/palette.scss
+++ b/src/ui/style/palette.scss
@@ -52,6 +52,8 @@ $switch-light-variant-1: #ffffff;
 $card-dark: #242433;
 $card-light: #f2f6f9;
 $card-background-disabled: #001526;
+$card-button-selected: #004564;
+$card-background-selected: rgba(0, 103, 150, 0.08);
 
 // menus
 $menu-dark: #121320;
@@ -65,7 +67,12 @@ $text-light: $primary-variant-1;
 
 // gradients
 $gradient: linear-gradient(270deg, #00b6b7 17.51%, #004073 100%);
-
+$card-background-light-gradient: linear-gradient(180deg, #f2f6f9 0%, rgba(242, 246, 249, 0) 100%);
+$card-background-dark-gradient: linear-gradient(
+  180deg,
+  rgba($card-dark, 0.8) 0%,
+  rgba($card-dark, 0) 100%
+);
 // semantic
 $success: #4ad377;
 $error: #ff3648;

--- a/src/ui/style/theme.scss
+++ b/src/ui/style/theme.scss
@@ -41,7 +41,7 @@ $themes: (
     skeleton-base-color: $skeleton-base-color-light,
     skeleton-animated-color: $skeleton-animated-color-light,
     skeleton-gradient:
-    linear-gradient(90deg, transparent, rgba($skeleton-animated-color-light, 0.04), transparent),
+      linear-gradient(90deg, transparent, rgba($skeleton-animated-color-light, 0.04), transparent),
     governance-nav-section-background: $governance-nav-section-background,
     article-background: $article-background-light,
     paragraph-background: $paragraph-background-light,
@@ -54,7 +54,10 @@ $themes: (
     tab-disabled-background: $tab-disabled-background,
     tab-disabled-text: $tab-disabled-text,
     tab-inactive-background: $tab-inactive-background-light,
-    tab-inactive-text: $tab-inactive-text-light
+    tab-inactive-text: $tab-inactive-text-light,
+    card-button-selected: $card-button-selected,
+    card-background-selected: $card-background-selected,
+    card-background-gradient: $card-background-light-gradient
   ),
   dark: (
     primary-color: $primary,
@@ -95,7 +98,7 @@ $themes: (
     skeleton-base-color: $skeleton-base-color-dark,
     skeleton-animated-color: $skeleton-animated-color-dark,
     skeleton-gradient:
-    linear-gradient(90deg, transparent, rgba($skeleton-animated-color-dark, 0.04), transparent),
+      linear-gradient(90deg, transparent, rgba($skeleton-animated-color-dark, 0.04), transparent),
     governance-nav-section-background: $tertiary-button-background-dark,
     article-background: $article-background-dark,
     paragraph-background: $paragraph-background-dark,
@@ -108,7 +111,10 @@ $themes: (
     tab-disabled-background: $tab-disabled-background,
     tab-disabled-text: $tab-disabled-text,
     tab-inactive-background: $tab-inactive-background-dark,
-    tab-inactive-text: $tab-inactive-text-dark
+    tab-inactive-text: $tab-inactive-text-dark,
+    card-button-selected: $card-button-selected,
+    card-background-selected: $card-background-selected,
+    card-background-gradient: $card-background-dark-gradient
   )
 );
 

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,1 +1,2 @@
 export type DataverseItem = 'dataspace' | 'dataset' | 'service'
+export type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -6,6 +6,7 @@ import type { DataverseItem } from '@/ui/types'
 import './dataverseItemCard.scss'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
+import { renderItemTypeColor } from '@/ui/common'
 
 export type DataverseItemCardProps = {
   type: DataverseItem

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -13,48 +13,36 @@ export type DataverseItemCardProps = {
   label: string
   topic: string
   button: JSX.Element
+  className?: string
 }
 
-export const DataverseItemCard: FC<DataverseItemCardProps> = ({ type, label, topic, button }) => {
+export const DataverseItemCard: FC<DataverseItemCardProps> = ({ type, label, topic, button,className }) => {
   const { t } = useTranslation('common')
 
-  type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
-
-  const renderItemTypeColor = useCallback((type: DataverseItem): ColorVariant => {
-    switch (type) {
-      case 'service':
-        return 'primary-color'
-      case 'dataspace':
-        return 'primary-color-variant-3'
-      case 'dataset':
-        return 'primary-color-variant-4'
-    }
-  }, [])
-
-  const renderItemContent = useCallback(
-    (label: string, topic: string): string => `### ${label}
+    const renderItemContent = useCallback(
+      (label: string, topic: string): string => `### ${label}
 ${topic}`,
-    []
-  )
+      []
+    )
 
-  return (
-    <Card>
-      <div className="okp4-dataverse-portal-dataverse-card-main">
-        <div
-          className={classNames(
-            'okp4-dataverse-portal-dataverse-item-type',
-            renderItemTypeColor(type)
-          )}
-        >
-          {t(`resources.${type}`)}
-        </div>
-        <div className="okp4-dataverse-portal-dataverse-item-card-content">
-          <div className="okp4-dataverse-portal-dataverse-topic">
-            <ReactMarkdown>{renderItemContent(label, topic)}</ReactMarkdown>
+    return (
+      <Card mainClassName={className}>
+        <div className="okp4-dataverse-portal-dataverse-card-main">
+          <div
+            className={classNames(
+              'okp4-dataverse-portal-dataverse-item-type',
+              renderItemTypeColor(type)
+            )}
+          >
+            {t(`resources.${type}`)}
           </div>
-          {button}
+          <div className="okp4-dataverse-portal-dataverse-item-card-content">
+            <div className="okp4-dataverse-portal-dataverse-topic">
+              <ReactMarkdown>{renderItemContent(label, topic)}</ReactMarkdown>
+            </div>
+            {button}
+          </div>
         </div>
-      </div>
-    </Card>
-  )
-}
+      </Card>
+    )
+  }

--- a/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemCard/dataverseItemCard.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react'
-import { useCallback } from 'react'
+import React, { useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { Card } from '@/ui/component/card/card'
 import type { DataverseItem } from '@/ui/types'
@@ -16,8 +15,9 @@ export type DataverseItemCardProps = {
   className?: string
 }
 
-export const DataverseItemCard: FC<DataverseItemCardProps> = ({ type, label, topic, button,className }) => {
-  const { t } = useTranslation('common')
+export const DataverseItemCard = React.forwardRef<HTMLDivElement, DataverseItemCardProps>(
+  ({ type, label, topic, button, className }, ref) => {
+    const { t } = useTranslation('common')
 
     const renderItemContent = useCallback(
       (label: string, topic: string): string => `### ${label}
@@ -27,7 +27,7 @@ ${topic}`,
 
     return (
       <Card mainClassName={className}>
-        <div className="okp4-dataverse-portal-dataverse-card-main">
+        <div className="okp4-dataverse-portal-dataverse-card-main" ref={ref}>
           <div
             className={classNames(
               'okp4-dataverse-portal-dataverse-item-type',
@@ -46,3 +46,6 @@ ${topic}`,
       </Card>
     )
   }
+)
+
+DataverseItemCard.displayName = 'DataverseItemCard'

--- a/src/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem.scss
+++ b/src/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem.scss
@@ -1,0 +1,5 @@
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-dataverse-item-details {
+  @include columns-with-gap(40px);
+}

--- a/src/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem.tsx
+++ b/src/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem.tsx
@@ -1,0 +1,73 @@
+import type { FC } from 'react'
+import { pipe } from 'fp-ts/lib/function'
+import * as A from 'fp-ts/Array'
+import classNames from 'classnames'
+import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
+import { GeneralMetadataList } from '@/ui/view/dataverse/component/generalMetadata/generalMetadata'
+import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
+import { SummaryMetadata } from '@/ui/view/dataverse/component/summaryMetadata/summaryMetadata'
+import ItemOverview from '@/ui/view/dataverse/component/itemOverview/itemOverview'
+import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
+import './detailedDataverseItem.scss'
+
+type DetailedDataverseItemProps = {
+  data: DataverseItemDetails
+  metadata: ItemGeneralMetadata[]
+  className?: string
+  onClose?: () => void
+}
+
+const propertiesWithIcon = [
+  'category',
+  'topic',
+  'format',
+  'license',
+  'geographicalCoverage',
+  'period'
+] as const
+
+type PropertyWithIcon = (typeof propertiesWithIcon)[number]
+
+const isPropertyWithIcon = (prop: string): prop is PropertyWithIcon =>
+  propertiesWithIcon.includes(prop as PropertyWithIcon)
+
+const isTagsMetadata = (
+  metadata: ItemGeneralMetadata
+): metadata is Omit<ItemGeneralMetadata, 'value'> & { property: 'tags'; value: string[] } =>
+  metadata.property === 'tags'
+
+const tags = (metadata: ItemGeneralMetadata[]): string[] =>
+  pipe(
+    metadata,
+    A.filter(isTagsMetadata),
+    A.flatMap(metadata => metadata.value)
+  )
+
+export const isGeneralMetadataWithIcon = (
+  metadata: ItemGeneralMetadata
+): metadata is Omit<ItemGeneralMetadata, 'value'> & { value: string } =>
+  metadata.category === 'generalMetadata' && isPropertyWithIcon(metadata.property)
+
+export const DetailedDataverseItem: FC<DetailedDataverseItemProps> = ({
+  data,
+  metadata,
+  className,
+  onClose
+}) => {
+  const generalMetadataWithIcon = pipe(metadata, A.filter(isGeneralMetadataWithIcon))
+
+  return (
+    <div className={classNames('okp4-dataverse-portal-dataverse-item-details', className)}>
+      <ItemOverview
+        description={data.description}
+        onClose={onClose}
+        tags={tags(metadata)}
+        title={data.label}
+      />
+      <GeneralMetadataList metadata={generalMetadataWithIcon} />
+      <SummaryMetadata metadata={metadata} />
+      {isDataSpace(data) && <GovernanceDescription description={data.governance.description} />}
+    </div>
+  )
+}

--- a/src/ui/view/dataverse/component/generalMetadata/generalMetadataValue.tsx
+++ b/src/ui/view/dataverse/component/generalMetadata/generalMetadataValue.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
-import { isGeneralMetadataWithIcon } from '@/ui/view/dataverse/component/pageTemplate/pageTemplate'
+import { isGeneralMetadataWithIcon } from '@/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem'
 import './generalMetadata.scss'
 import './i18n/index'
 import { DateInterval } from './dateInterval'

--- a/src/ui/view/dataverse/component/itemOverview/itemOverview.scss
+++ b/src/ui/view/dataverse/component/itemOverview/itemOverview.scss
@@ -2,38 +2,25 @@
 @import '@/ui/style/fonts.scss';
 @import '@/ui/style/mixins.scss';
 
-$colors: (
-  'primary-color',
-  'primary-color-variant-3',
-  'primary-color-variant-4'
-);
-
 .okp4-dataverse-portal-dataverse-item-overview-main {
   @include with-theme() {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    
-    .okp4-dataverse-portal-dataverse-item-overview-type {
-      @include noto-sans(700);
-      letter-spacing: 2px;
-      font-size: 14px;
-      line-height: 24px;
-      text-transform: uppercase;
-      @each $color-key in $colors {
-        &.#{$color-key} {
-          color: themed($color-key);
-        }
-      }
-    }
-    
+
     .okp4-dataverse-portal-dataverse-item-overview-title {
       @include noto-sans(700);
+      display: flex;
+      justify-content: space-between;
       font-size: 14px;
       color: themed('text');
       font-size: 24px;
+
+      .okp4-dataverse-portal-dataverse-item-overview-close {
+        cursor: pointer;
+      }
     }
-    
+
     .okp4-dataverse-portal-dataverse-item-overview-description {
       @include noto-sans(300);
       font-size: 16px;

--- a/src/ui/view/dataverse/component/itemOverview/itemOverview.tsx
+++ b/src/ui/view/dataverse/component/itemOverview/itemOverview.tsx
@@ -1,44 +1,33 @@
 import type { FC } from 'react'
-import { useCallback } from 'react'
-import { useTranslation } from 'react-i18next'
-import classNames from 'classnames'
 import { Tags } from '@/ui/view/dataverse/component//tags/tags'
-import type { DataverseItem } from '@/ui/types'
+import { Icon } from '@/ui/component/icon/icon'
+import { useAppStore } from '@/ui/store/appStore'
 import './itemOverview.scss'
 
 type ItemOverviewProps = {
-  type: DataverseItem
   title: string
   description: string
   tags: string[]
+  onClose?: () => void
 }
-type ColorVariant = 'primary-color' | 'primary-color-variant-3' | 'primary-color-variant-4'
 
-const ItemOverview: FC<ItemOverviewProps> = ({ type, title, description, tags }): JSX.Element => {
-  const { t } = useTranslation('common')
-
-  const renderItemTypeColor = useCallback((type: DataverseItem): ColorVariant => {
-    switch (type) {
-      case 'service':
-        return 'primary-color'
-      case 'dataspace':
-        return 'primary-color-variant-3'
-      case 'dataset':
-        return 'primary-color-variant-4'
-    }
-  }, [])
-
+const ItemOverview: FC<ItemOverviewProps> = ({
+  title,
+  description,
+  tags,
+  onClose
+}): JSX.Element => {
+  const theme = useAppStore(store => store.theme)
   return (
     <div className="okp4-dataverse-portal-dataverse-item-overview-main">
-      <h3
-        className={classNames(
-          'okp4-dataverse-portal-dataverse-item-overview-type',
-          renderItemTypeColor(type)
+      <h2 className="okp4-dataverse-portal-dataverse-item-overview-title">
+        <span>{title}</span>
+        {!!onClose && (
+          <div className="okp4-dataverse-portal-dataverse-item-overview-close" onClick={onClose}>
+            <Icon name={`close-${theme}`} />
+          </div>
         )}
-      >
-        {t(`resources.${type}`)}
-      </h3>
-      <h2 className="okp4-dataverse-portal-dataverse-item-overview-title">{title}</h2>
+      </h2>
       <p className="okp4-dataverse-portal-dataverse-item-overview-description">{description}</p>
       {tags.length > 0 && <Tags tags={tags} />}
     </div>

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.scss
@@ -1,39 +1,56 @@
 @import '@/ui/style/fonts.scss';
 @import '@/ui/style/mixins.scss';
+@import '@/ui/style/theme.scss';
+
+$colors: ('primary-color', 'primary-color-variant-3', 'primary-color-variant-4');
 
 .okp4-dataverse-portal-dataverse-component-page-template-main {
-  @include twelve-column-layout;
-  row-gap: 19px;
+  @include with-theme() {
+    @include twelve-column-layout;
+    row-gap: 19px;
 
-  @include use-breakpoints(('mobile')) {
-    row-gap: 13px;
-  }
+    @include use-breakpoints(('mobile')) {
+      row-gap: 13px;
+    }
 
-  .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
-    @include bi-column-item('left');
-    display: flex;
-    flex-direction: column;
-    row-gap: 40px;
-  }
+    .okp4-dataverse-portal-dataverse-page-template-left-side-wrapper {
+      @include bi-column-item('left');
 
-  .okp4-dataverse-portal-dataverse-page-template-right-side-wrapper {
-    @include bi-column-item($side: 'right');
+      .okp4-dataverse-portal-dataverse-item-overview-type {
+        @include noto-sans(700);
+        margin-bottom: 10px;
+        letter-spacing: 2px;
+        font-size: 14px;
+        line-height: 24px;
+        text-transform: uppercase;
 
-    h2 {
-      @include norse-gradient-header;
-      margin-bottom: 30px;
-
-      @include use-breakpoints(('mobile', 'tablet')) {
-        margin: 27px auto 30px;
+        @each $color-key in $colors {
+          &.#{$color-key} {
+            color: themed($color-key);
+          }
+        }
       }
     }
 
-    .okp4-dataverse-portal-dataverse-page-template-dataverse-item-stat-cards {
-      display: grid;
-      row-gap: 22px;
+    .okp4-dataverse-portal-dataverse-page-template-right-side-wrapper {
+      @include bi-column-item($side: 'right');
 
-      @include use-breakpoints(('mobile')) {
-        row-gap: 16px;
+      h2 {
+        @include norse-gradient-header;
+        margin-bottom: 30px;
+
+        @include use-breakpoints(('mobile', 'tablet')) {
+          margin: 27px auto 30px;
+        }
+      }
+
+      .okp4-dataverse-portal-dataverse-page-template-dataverse-item-stat-cards {
+        display: grid;
+        row-gap: 22px;
+
+        @include use-breakpoints(('mobile')) {
+          row-gap: 16px;
+        }
       }
     }
   }

--- a/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
+++ b/src/ui/view/dataverse/component/pageTemplate/pageTemplate.tsx
@@ -1,73 +1,37 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { pipe } from 'fp-ts/lib/function'
-import * as A from 'fp-ts/Array'
-import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import classNames from 'classnames'
 import type { ItemGeneralMetadata } from '@/ui/view/dataverse/types'
-import { GeneralMetadataList } from '@/ui/view/dataverse/component/generalMetadata/generalMetadata'
-import ItemOverview from '@/ui/view/dataverse/component/itemOverview/itemOverview'
-import { GovernanceDescription } from '@/ui/view/dataverse/component/governanceDescription/governanceDescription'
 import { isDataSpace } from '@/ui/page/dataverse/dataspace/dataspace'
 import { DataverseItemStatCard } from '@/ui/view/dataverse/component/dataverseItemStatCard/dataverseItemStatCard'
 import { BackButton } from '@/ui/view/dataverse/component/backButton/backButton'
-import './pageTemplate.scss'
+import type { DataverseItemDetails } from '@/ui/page/dataverse/dataverse'
+import { DetailedDataverseItem } from '@/ui/view/dataverse/component/dataverseItemDetails/detailedDataverseItem'
+import { renderItemTypeColor } from '@/ui/common'
 import './i18n/index'
-import { SummaryMetadata } from '@/ui/view/dataverse/component/summaryMetadata/summaryMetadata'
+import './pageTemplate.scss'
 
 type PageTemplateProps = {
   data: DataverseItemDetails
   metadata: ItemGeneralMetadata[]
 }
 
-const propertiesWithIcon = [
-  'category',
-  'topic',
-  'format',
-  'license',
-  'geographicalCoverage',
-  'period'
-] as const
-
-type PropertyWithIcon = (typeof propertiesWithIcon)[number]
-
-const isPropertyWithIcon = (prop: string): prop is PropertyWithIcon =>
-  propertiesWithIcon.includes(prop as PropertyWithIcon)
-
-const isTagsMetadata = (
-  metadata: ItemGeneralMetadata
-): metadata is Omit<ItemGeneralMetadata, 'value'> & { property: 'tags'; value: string[] } =>
-  metadata.property === 'tags'
-
-export const isGeneralMetadataWithIcon = (
-  metadata: ItemGeneralMetadata
-): metadata is Omit<ItemGeneralMetadata, 'value'> & { value: string } =>
-  metadata.category === 'generalMetadata' && isPropertyWithIcon(metadata.property)
-
-const tags = (metadata: ItemGeneralMetadata[]): string[] =>
-  pipe(
-    metadata,
-    A.filter(isTagsMetadata),
-    A.flatMap(metadata => metadata.value)
-  )
-
 const PageTemplate: FC<PageTemplateProps> = ({ data, metadata }) => {
   const { t } = useTranslation(['pageTemplate', 'common'])
-
-  const generalMetadataWithIcon = pipe(metadata, A.filter(isGeneralMetadataWithIcon))
 
   return (
     <div className="okp4-dataverse-portal-dataverse-component-page-template-main">
       <BackButton label={t('dataverse')} to="/dataverse" />
       <div className="okp4-dataverse-portal-dataverse-page-template-left-side-wrapper">
-        <ItemOverview
-          description={data.description}
-          tags={tags(metadata)}
-          title={data.label}
-          type={data.type}
-        />
-        <GeneralMetadataList metadata={generalMetadataWithIcon} />
-        <SummaryMetadata metadata={metadata} />
-        {isDataSpace(data) && <GovernanceDescription description={data.governance.description} />}
+        <h3
+          className={classNames(
+            'okp4-dataverse-portal-dataverse-item-overview-type',
+            renderItemTypeColor(data.type)
+          )}
+        >
+          {t(`resources.${data.type}`)}
+        </h3>
+        <DetailedDataverseItem data={data} metadata={metadata} />
       </div>
       <div className="okp4-dataverse-portal-dataverse-page-template-right-side-wrapper">
         {isDataSpace(data) && (


### PR DESCRIPTION
This PR implements this [issue](https://github.com/okp4/dataverse-portal/issues/237) which allows the user to  display service details by clicking on its card.

Please note that 1st version won't have any animation when details part is opened/closed.