### PR TITLE
Feat/create stepper progress component

### DIFF
--- a/src/ui/component/stepper/stepperProgress/progressBar/progressBar.scss
+++ b/src/ui/component/stepper/stepperProgress/progressBar/progressBar.scss
@@ -1,0 +1,73 @@
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+$transition-duration: 600ms;
+
+.okp4-dataverse-portal-progress-bar-main {
+  @include with-theme {
+    width: 40px;
+    height: 6px;
+    border-radius: 3px;
+    position: relative;
+    overflow: hidden;
+    background-color: rgba(themed('text'), 0.12);
+    
+    &.delayed-transition {
+      transition-delay: $transition-duration;
+    }
+    
+    &.active {
+      background-color: themed('primary-color-variant-3');
+      transition-duration: $transition-duration;
+      transition-property: background-color;
+    }
+    
+    &.complete {
+      background-color: themed('success');
+      transition-duration: $transition-duration;
+      transition-property: background-color;
+    }
+  
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-color: themed('primary-color-variant-3');
+      transform: translateX(-100%);
+    }
+
+    &.none::before {
+      transform: translateX(-100%);
+    }
+    
+    &.forward::before {
+      animation: progress-forward $transition-duration forwards;
+    } 
+    
+    &.backward::before {
+      animation: progress-backward $transition-duration forwards;
+    }
+  }
+}
+
+@keyframes progress-backward {
+  from {
+    transform: translateX(0%);
+  }
+  
+  to {
+    transform: translateX(-100%);
+  }
+}
+    
+  
+@keyframes progress-forward {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(0%);
+  }
+}
+  

--- a/src/ui/component/stepper/stepperProgress/progressBar/progressBar.tsx
+++ b/src/ui/component/stepper/stepperProgress/progressBar/progressBar.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames'
+import type { FC } from 'react'
+import type { StepStatus } from '../stepperProgress'
+import './progressBar.scss'
+
+type ProgressBarState = 'active' | Extract<StepStatus, 'complete' | 'incomplete'>
+export type ProgressBarTransition = 'none' | 'backward' | 'forward'
+
+type ProgressBarProps = {
+  state: ProgressBarState
+  transition: ProgressBarTransition
+}
+
+export const ProgressBar: FC<ProgressBarProps> = ({ state, transition }) => (
+  <div
+    className={classNames('okp4-dataverse-portal-progress-bar-main', state, transition, {
+      'delayed-transition': transition === 'forward'
+    })}
+  />
+)

--- a/src/ui/component/stepper/stepperProgress/stepperProgress.scss
+++ b/src/ui/component/stepper/stepperProgress/stepperProgress.scss
@@ -1,0 +1,18 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-stepper-progress-main {
+  @include with-theme {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .okp4-dataverse-portal-stepper-progress-step-count {
+      font-size: 16px;
+      @include noto-sans(400);
+      color: rgba(themed('text'), 0.4);
+      line-height: 22px;
+    }
+  }
+}

--- a/src/ui/component/stepper/stepperProgress/stepperProgress.tsx
+++ b/src/ui/component/stepper/stepperProgress/stepperProgress.tsx
@@ -1,0 +1,68 @@
+import type { FC } from 'react'
+import type { ProgressBarTransition } from './progressBar/progressBar'
+import { ProgressBar } from './progressBar/progressBar'
+import './stepperProgress.scss'
+
+type StepId = string
+export type StepStatus = 'error' | 'disabled' | 'complete' | 'incomplete'
+
+type Step = {
+  id: StepId
+  order: number
+  status: StepStatus
+}
+
+type StepperProgressProps = {
+  steps: Step[]
+  activeStepId: StepId
+  previousActiveStepId: StepId
+}
+
+const getProgressBarTransition = ({
+  stepOrder,
+  activeStepOrder,
+  previousActiveStepOrder
+}: {
+  stepOrder: number
+  activeStepOrder: number
+  previousActiveStepOrder: number
+}): ProgressBarTransition => {
+  if (stepOrder === activeStepOrder && previousActiveStepOrder < stepOrder) {
+    return 'forward'
+  }
+  if (stepOrder === previousActiveStepOrder && activeStepOrder < stepOrder) {
+    return 'backward'
+  }
+  return 'none'
+}
+
+const findStep = (steps: Step[], stepId: StepId): Step =>
+  steps.find(({ id }) => id === stepId) ?? steps[0]
+
+export const StepperProgress: FC<StepperProgressProps> = ({
+  steps,
+  activeStepId,
+  previousActiveStepId
+}) => {
+  const activeStep = findStep(steps, activeStepId)
+  const previousActiveStep = findStep(steps, previousActiveStepId)
+
+  return (
+    <div className="okp4-dataverse-portal-stepper-progress-main">
+      {steps.map(({ id, status, order }) => (
+        <ProgressBar
+          key={id}
+          state={id === activeStepId ? 'active' : status === 'complete' ? 'complete' : 'incomplete'}
+          transition={getProgressBarTransition({
+            stepOrder: order,
+            activeStepOrder: activeStep.order,
+            previousActiveStepOrder: previousActiveStep.order
+          })}
+        />
+      ))}
+      <span className="okp4-dataverse-portal-stepper-progress-step-count">
+        {activeStep.order + 1 + '/' + steps.length}
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Stepper Progress component creation

This PR introduces `StepperProgress` and `ProgressBar` components, designed to provide an overview of the progression for [the Stepper](https://github.com/okp4/dataverse-portal/issues/236).

The entire Stepper component is developed in parallel in [this PR](https://github.com/okp4/dataverse-portal/pull/314).
Creating two separates PR make it easier to read and review.

### Behavior


A video from [this comment](https://github.com/okp4/dataverse-portal/issues/236#issuecomment-1582172446) provides more details for the Stepper Progress behavior.

#### When Next step is reached
- the previous step changes from background blue (active) to validate (green).
- the next step changes from gray (default status) to blue (active), via a translation on the X axis.
#### When the previous step is reached
- the step that was active returns to its previous state via a reverse translation on the X axis
- the step that becomes active changes to blue with a transition on the background

### Usage
The`StepperProgress` will be a part of the Stepper component from [this technical specification](https://github.com/okp4/dataverse-portal/issues/236#issuecomment-1578757452).

### Visual example
<img width="394" alt="image" src="https://github.com/okp4/dataverse-portal/assets/8344874/9ec7dcb4-4678-44aa-a84d-48a96207fb88">

### Testing
A test can be performed from the branch of the PR #314 , that includes both commits.