### PR TITLE
feat(filepicker): return file and path on file change

### DIFF
--- a/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
+++ b/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
@@ -21,10 +21,10 @@ export const DataSelection: FC = () => {
   const handleFileChange = useCallback(
     (files: File[]): void => {
       const storeFilesInput: StoreFilesInput = files.map(
-        ({ name, fullPath: path, size, stream, mediaType: type }: File) => ({
+        ({ name, webkitRelativePath, size, stream, type }: File) => ({
           id: short.generate(),
           name,
-          path,
+          path: webkitRelativePath ? webkitRelativePath : `/${name}`,
           type,
           stream,
           size


### PR DESCRIPTION
This PR is to make the `<FilePicker />` more generic by returning the file itself on the callback. a path property is attached to simplify path handling for files without relative path.