### PR TITLE
Feat/add list item transition

### DIFF
--- a/src/ui/component/list/list.scss
+++ b/src/ui/component/list/list.scss
@@ -2,38 +2,62 @@
 @import '@/ui/style/mixins.scss';
 @import '@/ui/style/theme.scss';
 
+$transition-duration: 400ms;
+
 .okp4-dataverse-portal-list-main {
-  @include columns-with-gap(16px);
-  list-style: none;
   padding: 0;
-}
 
-.okp4-dataverse-portal-list-item-main {
-  @include with-theme {
-    display: grid;
-    column-gap: 14px;
-    grid-template-columns: 1fr;
-    align-items: center;
-    padding: 16px 13px;
-    border-radius: 12px;
-    background-color: themed('list-item');
-    color: themed('text');
-    @include noto-sans(400);
+  .okp4-dataverse-portal-list-container {
+    @include columns-with-gap(16px);
+    list-style: none;
 
-    &.clickable {
-      cursor: pointer;
-    }
+    .okp4-dataverse-portal-list-item-main {
+      @include with-theme {
+        @include noto-sans(400);
+        display: grid;
+        column-gap: 14px;
+        grid-template-columns: 1fr;
+        align-items: center;
+        padding: 16px 13px;
+        border-radius: 12px;
+        background-color: themed('list-item');
+        color: themed('text');
 
-    &.list-item-3-columns {
-      grid-template-columns: auto 1fr auto;
-    }
+        &.clickable {
+          cursor: pointer;
+        }
 
-    &.list-item-2-columns-left {
-      grid-template-columns: auto 1fr;
-    }
+        &.list-item-3-columns {
+          grid-template-columns: auto 1fr auto;
+        }
 
-    &.list-item-2-columns-right {
-      grid-template-columns: 1fr auto;
+        &.list-item-2-columns-left {
+          grid-template-columns: auto 1fr;
+        }
+
+        &.list-item-2-columns-right {
+          grid-template-columns: 1fr auto;
+        }
+
+        &.transition-enter {
+          opacity: 0;
+        }
+
+        &.transition-enter-active {
+          opacity: 1;
+          transition: opacity calc($transition-duration / 2) ease-out;
+          transition-delay: calc($transition-duration / 2);
+        }
+
+        &.transition-exit {
+          opacity: 1;
+        }
+
+        &.transition-exit-active {
+          opacity: 0;
+          transition: opacity calc($transition-duration / 2) ease-out;
+        }
+      }
     }
   }
 }

--- a/src/ui/component/list/list.tsx
+++ b/src/ui/component/list/list.tsx
@@ -1,14 +1,7 @@
-import type { FC, ReactElement, ReactNode } from 'react'
+import type { FC, ReactElement } from 'react'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import classNames from 'classnames'
 import './list.scss'
-
-type ListItemProps = {
-  content: ReactElement
-  leftElement?: ReactElement
-  rightElement?: ReactElement
-  onClick?: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void
-  className?: string
-}
 
 const gridTemplateColumnClasses = (
   leftElement?: ReactElement,
@@ -20,33 +13,41 @@ const gridTemplateColumnClasses = (
   return 'list-item-1-column'
 }
 
-export const ListItem: FC<ListItemProps> = ({
-  leftElement,
-  rightElement,
-  content,
-  onClick,
-  className
-}) => (
-  <li
-    className={classNames(
-      'okp4-dataverse-portal-list-item-main',
-      { clickable: onClick },
-      gridTemplateColumnClasses(leftElement, rightElement),
-      className
-    )}
-    onClick={onClick}
-  >
-    {leftElement}
-    {content}
-    {rightElement}
-  </li>
-)
+export type Item = {
+  id: string
+  className?: string
+  content: ReactElement
+  leftElement?: ReactElement
+  rightElement?: ReactElement
+  onClick?: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void
+}
 
 type ListProps = {
-  children: ReactNode
+  items: Item[]
   className?: string
 }
 
-export const List: FC<ListProps> = ({ children, className }) => (
-  <ul className={classNames('okp4-dataverse-portal-list-main', className)}>{children}</ul>
+export const List: FC<ListProps> = ({ items, className }) => (
+  <ul className={classNames('okp4-dataverse-portal-list-main', className)}>
+    <TransitionGroup className="okp4-dataverse-portal-list-container">
+      {items.map(({ leftElement, rightElement, content, className, id, onClick }) => (
+        <CSSTransition classNames="transition" key={id} timeout={400}>
+          <li
+            className={classNames(
+              'okp4-dataverse-portal-list-item-main',
+              { clickable: onClick },
+              gridTemplateColumnClasses(leftElement, rightElement),
+              className
+            )}
+            key={id}
+            onClick={onClick}
+          >
+            {leftElement}
+            {content}
+            {rightElement}
+          </li>
+        </CSSTransition>
+      ))}
+    </TransitionGroup>
+  </ul>
 )

--- a/src/ui/component/list/list.tsx
+++ b/src/ui/component/list/list.tsx
@@ -24,11 +24,13 @@ export type Item = {
 
 type ListProps = {
   items: Item[]
-  className?: string
+  classes?: {
+    main?: string
+  }
 }
 
-export const List: FC<ListProps> = ({ items, className }) => (
-  <ul className={classNames('okp4-dataverse-portal-list-main', className)}>
+export const List: FC<ListProps> = ({ items, classes }) => (
+  <ul className={classNames('okp4-dataverse-portal-list-main', classes?.main)}>
     <TransitionGroup className="okp4-dataverse-portal-list-container">
       {items.map(({ leftElement, rightElement, content, className, id, onClick }) => (
         <CSSTransition classNames="transition" key={id} timeout={400}>

--- a/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
+++ b/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
@@ -4,11 +4,12 @@ import { useTranslation } from 'react-i18next'
 import * as short from 'short-uuid'
 import type { File } from '@/ui/component/filePicker/filePicker'
 import { FilePicker } from '@/ui/component/filePicker/filePicker'
-import { List, ListItem } from '@/ui/component/list/list'
+import { type Item, List } from '@/ui/component/list/list'
 import { Icon } from '@/ui/component/icon/icon'
 import { useFileStore } from '@/ui/store'
 import type { StoreFilesInput } from '@/domain/file/command'
 import './dataSelection.scss'
+import type { FilesDescriptor } from '@/domain/file/query'
 
 export const DataSelection: FC = () => {
   const { t } = useTranslation('share')
@@ -38,6 +39,27 @@ export const DataSelection: FC = () => {
     [removeFile]
   )
 
+  const mapToListItems = (files: FilesDescriptor): Item[] => {
+    return files.map(({ id, name }) => ({
+      content: <p>{name}</p>,
+      id: id,
+      key: id,
+      leftElement: (
+        <div className="okp4-dataverse-portal-share-dataset-page-file-icon">
+          <Icon name="folder-outlined" />
+        </div>
+      ),
+      rightElement: (
+        <div
+          className="okp4-dataverse-portal-share-dataset-page-file-deletion"
+          onClick={handleFileDeletion(id)}
+        >
+          <Icon name="bin" />
+        </div>
+      )
+    }))
+  }
+
   return (
     <div className="okp4-dataverse-portal-share-data-selection-container">
       <h2>{t('share:share.dataset.select')}</h2>
@@ -48,27 +70,10 @@ export const DataSelection: FC = () => {
         <FilePicker hasFileExplorer hasFolderExplorer multiple onFileChange={handleFiles} />
       </div>
       <div className="okp4-dataverse-portal-share-dataset-page-file-list-container">
-        <List className="okp4-dataverse-portal-share-dataset-page-file-list">
-          {files()().map(({ id, name }) => (
-            <ListItem
-              content={<p>{name}</p>}
-              key={id}
-              leftElement={
-                <div className="okp4-dataverse-portal-share-dataset-page-file-icon">
-                  <Icon name="folder-outlined" />
-                </div>
-              }
-              rightElement={
-                <div
-                  className="okp4-dataverse-portal-share-dataset-page-file-deletion"
-                  onClick={handleFileDeletion(id)}
-                >
-                  <Icon name="bin" />
-                </div>
-              }
-            />
-          ))}
-        </List>
+        <List
+          className="okp4-dataverse-portal-share-dataset-page-file-list"
+          items={mapToListItems(files()())}
+        />
       </div>
     </div>
   )

--- a/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
+++ b/src/ui/page/share/dataset/steps/dataSelection/dataSelection.tsx
@@ -9,7 +9,6 @@ import { Icon } from '@/ui/component/icon/icon'
 import { useFileStore } from '@/ui/store'
 import type { StoreFilesInput } from '@/domain/file/command'
 import './dataSelection.scss'
-import type { FilesDescriptor } from '@/domain/file/query'
 
 export const DataSelection: FC = () => {
   const { t } = useTranslation('share')
@@ -19,17 +18,19 @@ export const DataSelection: FC = () => {
     storeFiles: state.storeFiles
   }))
 
-  const handleFiles = useCallback(
+  const handleFileChange = useCallback(
     (files: File[]): void => {
-      const mappedStoreFiles: StoreFilesInput = files.map((file: File) => ({
-        id: short.generate(),
-        name: file.name,
-        path: file.fullPath,
-        type: file.mediaType,
-        stream: file.stream,
-        size: file.size
-      }))
-      storeFiles(mappedStoreFiles)()
+      const storeFilesInput: StoreFilesInput = files.map(
+        ({ name, fullPath: path, size, stream, mediaType: type }: File) => ({
+          id: short.generate(),
+          name,
+          path,
+          type,
+          stream,
+          size
+        })
+      )
+      storeFiles(storeFilesInput)()
     },
     [storeFiles]
   )
@@ -39,26 +40,24 @@ export const DataSelection: FC = () => {
     [removeFile]
   )
 
-  const mapToListItems = (files: FilesDescriptor): Item[] => {
-    return files.map(({ id, name }) => ({
-      content: <p>{name}</p>,
-      id: id,
-      key: id,
-      leftElement: (
-        <div className="okp4-dataverse-portal-share-dataset-page-file-icon">
-          <Icon name="folder-outlined" />
-        </div>
-      ),
-      rightElement: (
-        <div
-          className="okp4-dataverse-portal-share-dataset-page-file-deletion"
-          onClick={handleFileDeletion(id)}
-        >
-          <Icon name="bin" />
-        </div>
-      )
-    }))
-  }
+  const items: Item[] = files()().map(({ id, name }) => ({
+    content: <p>{name}</p>,
+    id,
+    key: id,
+    leftElement: (
+      <div className="okp4-dataverse-portal-share-dataset-page-file-icon">
+        <Icon name="folder-outlined" />
+      </div>
+    ),
+    rightElement: (
+      <div
+        className="okp4-dataverse-portal-share-dataset-page-file-deletion"
+        onClick={handleFileDeletion(id)}
+      >
+        <Icon name="bin" />
+      </div>
+    )
+  }))
 
   return (
     <div className="okp4-dataverse-portal-share-data-selection-container">
@@ -67,12 +66,12 @@ export const DataSelection: FC = () => {
         <h3>{t('share:share.dataset.selectDescription')}</h3>
       </div>
       <div className="okp4-dataverse-portal-share-data-selection-drag-drop-container">
-        <FilePicker hasFileExplorer hasFolderExplorer multiple onFileChange={handleFiles} />
+        <FilePicker hasFileExplorer hasFolderExplorer multiple onFileChange={handleFileChange} />
       </div>
       <div className="okp4-dataverse-portal-share-dataset-page-file-list-container">
         <List
-          className="okp4-dataverse-portal-share-dataset-page-file-list"
-          items={mapToListItems(files()())}
+          classes={{ main: 'okp4-dataverse-portal-share-dataset-page-file-list' }}
+          items={items}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR adds the list item transition (visible in data selection step) by updating the component `List` with `React CSS Transition`.

For now the transition is 400ms to be compliant will all portal transitions (to be configured in the future)