### PR TITLE
fix(infra): escape double quotes in filter literals

### DIFF
--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -10,7 +10,7 @@ import type {
   RetrieveDataverseResult,
   DataverseElementType
 } from '@/domain/dataverse/port'
-import { escapeRegExp, getURILastElement } from '@/util/util'
+import { escapeSparqlStr, getURILastElement } from '@/util/util'
 import { createAbortableFetch } from '@/util/fetch/fetch'
 import type { SparqlBinding, SparqlResult } from './dto'
 const { abortRequest, fetchWithAbort } = createAbortableFetch()
@@ -32,7 +32,7 @@ export const sparqlGateway: DataversePort = {
         byProperty,
         O.map(
           filter =>
-            `FILTER ( contains(lcase(str(?${filter.property})), "${escapeRegExp(
+            `FILTER ( contains(lcase(str(?${filter.property})), "${escapeSparqlStr(
               filter.value.toLowerCase()
             )}" ) )`
         ),

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -30,13 +30,13 @@ export const sparqlGateway: DataversePort = {
     const byPropertyFilter = (): string =>
       pipe(
         byProperty,
-        O.map(
+        O.match(
+          () => '',
           filter =>
             `FILTER ( contains(lcase(str(?${filter.property})), "${escapeSparqlStr(
               filter.value.toLowerCase()
             )}" ) )`
-        ),
-        O.getOrElse(() => '')
+        )
       )
 
     const byServiceCategoryFilter = (): string =>

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -10,7 +10,7 @@ import type {
   RetrieveDataverseResult,
   DataverseElementType
 } from '@/domain/dataverse/port'
-import { getURILastElement } from '@/util/util'
+import { escapeRegExp, getURILastElement } from '@/util/util'
 import { createAbortableFetch } from '@/util/fetch/fetch'
 import type { SparqlBinding, SparqlResult } from './dto'
 const { abortRequest, fetchWithAbort } = createAbortableFetch()
@@ -32,9 +32,9 @@ export const sparqlGateway: DataversePort = {
         byProperty,
         O.map(
           filter =>
-            `FILTER ( contains(lcase(str(?${filter.property})), "${filter.value
-              .toLowerCase()
-              .replace(/"/g, '\\"')}" ) )`
+            `FILTER ( contains(lcase(str(?${filter.property})), "${escapeRegExp(
+              filter.value.toLowerCase()
+            )}" ) )`
         ),
         O.getOrElse(() => '')
       )

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -32,7 +32,9 @@ export const sparqlGateway: DataversePort = {
         byProperty,
         O.map(
           filter =>
-            `FILTER ( contains(lcase(str(?${filter.property})), "${filter.value.toLowerCase()}" ) )`
+            `FILTER ( contains(lcase(str(?${filter.property})), "${filter.value
+              .toLowerCase()
+              .replace(/"/g, '\\"')}" ) )`
         ),
         O.getOrElse(() => '')
       )

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -75,26 +75,29 @@ describe('isError guard function', () => {
 
 describe('escapeSparqlStr', () => {
   describe.each`
-    arg             | expectedResult
-    ${undefined}    | ${''}
-    ${'\t'}         | ${'\\t'}
-    ${'\n'}         | ${'\\n'}
-    ${'\r'}         | ${'\\r'}
-    ${'\b'}         | ${'\\b'}
-    ${'\f'}         | ${'\\f'}
-    ${'"'}          | ${'\\"'}
-    ${"'"}          | ${"\\'"}
-    ${'\\'}         | ${'\\\\'}
-    ${'foo\nbar'}   | ${'foo\\nbar'}
-    ${'foo\n'}      | ${'foo\\n'}
-    ${'\nfoo'}      | ${'\\nfoo'}
-    ${'foo"bar'}    | ${'foo\\"bar'}
-    ${"foo'bar"}    | ${"foo\\'bar"}
-    ${'foo\\bar'}   | ${'foo\\\\bar'}
-    ${'\\u00a0'}    | ${'\\\\u00a0'}
-    ${'\u00a0'}     | ${' '}
-    ${'\u005Cbar'}  | ${'\\\\bar'}
-    ${'\\u005Cbar'} | ${'\\\\u005Cbar'}
+    arg                    | expectedResult
+    ${undefined}           | ${''}
+    ${'\t'}                | ${'\\t'}
+    ${'\n'}                | ${'\\n'}
+    ${'\r'}                | ${'\\r'}
+    ${'\b'}                | ${'\\b'}
+    ${'\f'}                | ${'\\f'}
+    ${'"'}                 | ${'\\"'}
+    ${"'"}                 | ${"\\'"}
+    ${'\\'}                | ${'\\\\'}
+    ${'foo\nbar'}          | ${'foo\\nbar'}
+    ${'foo\n'}             | ${'foo\\n'}
+    ${'\nfoo'}             | ${'\\nfoo'}
+    ${'foo"bar'}           | ${'foo\\"bar'}
+    ${"foo'bar"}           | ${"foo\\'bar"}
+    ${'foo\\bar'}          | ${'foo\\\\bar'}
+    ${'foo\t\tbar\n\nbaz'} | ${'foo\\t\\tbar\\n\\nbaz'}
+    ${'/foo^?*bar$baz+'}   | ${'/foo^?*bar$baz+'}
+    ${'\\...🧪✌🏾'}         | ${'\\\\...🧪✌🏾'}
+    ${'\\u00a0'}           | ${'\\\\u00a0'}
+    ${'\u00a0'}            | ${' '}
+    ${'\u005Cbar'}         | ${'\\\\bar'}
+    ${'\\u005Cbar'}        | ${'\\\\u005Cbar'}
   `('When given argument <"$arg">', ({ arg, expectedResult }) => {
     it(`returns ${expectedResult}`, () => {
       expect(escapeSparqlStr(arg)).toBe(expectedResult)

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,4 +1,4 @@
-import { getURILastElement, isError, isSubstringOf, escapeRegExp } from './util'
+import { getURILastElement, isError, isSubstringOf, escapeSparqlStr } from './util'
 import * as O from 'fp-ts/Option'
 
 type Data = {
@@ -73,20 +73,31 @@ describe('isError guard function', () => {
   })
 })
 
-describe('Considering the escapeRegExp() function', () => {
+describe('escapeSparqlStr', () => {
   describe.each`
-    arg                  | expectedResult
-    ${undefined}         | ${''}
-    ${'foo'}             | ${'foo'}
-    ${'^.$*()[]|?\\{}+'} | ${'\\^\\.\\$\\*\\(\\)\\[\\]\\|\\?\\\\\\{\\}\\+'}
-    ${'foo"'}            | ${'foo\\"'}
-    ${"foo'"}            | ${"foo\\'"}
-  `('Given an argument <"$arg">', ({ arg, expectedResult }: Data) => {
-    describe('When calling function escapeRegExp()', () => {
-      const result = escapeRegExp(arg)
-      test('Then, the result is as expected', () => {
-        expect(result).toStrictEqual(expectedResult)
-      })
+    arg             | expectedResult
+    ${undefined}    | ${''}
+    ${'\t'}         | ${'\\t'}
+    ${'\n'}         | ${'\\n'}
+    ${'\r'}         | ${'\\r'}
+    ${'\b'}         | ${'\\b'}
+    ${'\f'}         | ${'\\f'}
+    ${'"'}          | ${'\\"'}
+    ${"'"}          | ${"\\'"}
+    ${'\\'}         | ${'\\\\'}
+    ${'foo\nbar'}   | ${'foo\\nbar'}
+    ${'foo\n'}      | ${'foo\\n'}
+    ${'\nfoo'}      | ${'\\nfoo'}
+    ${'foo"bar'}    | ${'foo\\"bar'}
+    ${"foo'bar"}    | ${"foo\\'bar"}
+    ${'foo\\bar'}   | ${'foo\\\\bar'}
+    ${'\\u00a0'}    | ${'\\\\u00a0'}
+    ${'\u00a0'}     | ${' '}
+    ${'\u005Cbar'}  | ${'\\\\bar'}
+    ${'\\u005Cbar'} | ${'\\\\u005Cbar'}
+  `('When given argument <"$arg">', ({ arg, expectedResult }) => {
+    it(`returns ${expectedResult}`, () => {
+      expect(escapeSparqlStr(arg)).toBe(expectedResult)
     })
   })
 })

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,4 +1,4 @@
-import { getURILastElement, isError, isSubstringOf } from './util'
+import { getURILastElement, isError, isSubstringOf, escapeRegExp } from './util'
 import * as O from 'fp-ts/Option'
 
 type Data = {
@@ -66,6 +66,24 @@ describe('isError guard function', () => {
   `('Given an argument <"$arg">', ({ arg, expectedResult }: Data) => {
     describe('When checking the type of the value in the function isError(value)', () => {
       const result = isError(arg)
+      test('Then, the result is as expected', () => {
+        expect(result).toStrictEqual(expectedResult)
+      })
+    })
+  })
+})
+
+describe('Considering the escapeRegExp() function', () => {
+  describe.each`
+    arg                  | expectedResult
+    ${undefined}         | ${''}
+    ${'foo'}             | ${'foo'}
+    ${'^.$*()[]|?\\{}+'} | ${'\\^\\.\\$\\*\\(\\)\\[\\]\\|\\?\\\\\\{\\}\\+'}
+    ${'foo"'}            | ${'foo\\"'}
+    ${"foo'"}            | ${"foo\\'"}
+  `('Given an argument <"$arg">', ({ arg, expectedResult }: Data) => {
+    describe('When calling function escapeRegExp()', () => {
+      const result = escapeRegExp(arg)
       test('Then, the result is as expected', () => {
         expect(result).toStrictEqual(expectedResult)
       })

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -39,7 +39,7 @@ export const isSubstringOf = (substring: string, source: string): boolean =>
 export const isError = (value: unknown): value is Error => value instanceof Error
 
 export const escapeRegExp = (str?: string): string => {
-  const slashedRegExp = /[\\^"'$.*+?()[\]{}|]/g
-  const regExp = RegExp(slashedRegExp.source)
-  return str && regExp.test(str) ? str.replace(regExp, '\\$&') : str ?? ''
+  const regExp = /[\\^"'$.*+?()[\]{}|]/g
+  const regExpFromSource = RegExp(regExp.source)
+  return str && regExpFromSource.test(str) ? str.replace(regExp, '\\$&') : str ?? ''
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -37,3 +37,9 @@ export const isSubstringOf = (substring: string, source: string): boolean =>
   pipe(source, S.toLowerCase, S.includes(S.toLowerCase(substring)))
 
 export const isError = (value: unknown): value is Error => value instanceof Error
+
+export const escapeRegExp = (str?: string): string => {
+  const slashedRegExp = /[\\^"'$.*+?()[\]{}|]/g
+  const regExp = RegExp(slashedRegExp.source)
+  return str && regExp.test(str) ? str.replace(regExp, '\\$&') : str ?? ''
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -2,7 +2,9 @@ import * as O from 'fp-ts/Option'
 import * as A from 'fp-ts/Array'
 import * as T from 'fp-ts/Task'
 import * as S from 'fp-ts/string'
-import { flow, pipe } from 'fp-ts/function'
+import * as R from 'fp-ts/Record'
+import * as RA from 'fp-ts/ReadonlyArray'
+import { constant, flow, pipe } from 'fp-ts/function'
 import { error, info, log, warn } from 'fp-ts/lib/Console'
 import type { IO } from 'fp-ts/lib/IO'
 import type { Task } from 'fp-ts/lib/Task'
@@ -50,17 +52,15 @@ export const escapeSparqlStr = (str?: string): string => {
     '\\': '\\\\'
   }
 
+  const lookupEscapeCharacter = (c: string): string =>
+    pipe(escapeCharactersMap, R.lookup(c), O.getOrElse(constant(c)))
+
   return pipe(
     str,
     O.fromNullable,
-    O.map(s =>
-      pipe(
-        s,
-        Array.from,
-        A.map((char: string) => escapeCharactersMap[char] || char),
-        (chars: string[]) => chars.join('')
-      )
-    ),
-    O.getOrElse(() => '')
+    O.getOrElse(constant(S.empty)),
+    S.split(S.empty),
+    RA.map(lookupEscapeCharacter),
+    RA.reduce(S.Monoid.empty, S.Monoid.concat)
   )
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -38,8 +38,19 @@ export const isSubstringOf = (substring: string, source: string): boolean =>
 
 export const isError = (value: unknown): value is Error => value instanceof Error
 
-export const escapeRegExp = (str?: string): string => {
-  const regExp = /[\\^"'$.*+?()[\]{}|]/g
-  const regExpFromSource = RegExp(regExp.source)
-  return str && regExpFromSource.test(str) ? str.replace(regExp, '\\$&') : str ?? ''
+export const escapeSparqlStr = (str?: string): string => {
+  const sparqlEscapeRegExp = /[\t\n\r\b\f"'\\]/g
+
+  const escapeCharactersMap = new Map([
+    ['\t', '\\t'],
+    ['\n', '\\n'],
+    ['\r', '\\r'],
+    ['\b', '\\b'],
+    ['\f', '\\f'],
+    ['"', '\\"'],
+    ["'", "\\'"],
+    ['\\', '\\\\']
+  ])
+
+  return str ? str.replace(sparqlEscapeRegExp, char => escapeCharactersMap.get(char) as string) : ''
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,4 +1,4 @@
-import type * as O from 'fp-ts/Option'
+import * as O from 'fp-ts/Option'
 import * as A from 'fp-ts/Array'
 import * as T from 'fp-ts/Task'
 import * as S from 'fp-ts/string'
@@ -39,18 +39,28 @@ export const isSubstringOf = (substring: string, source: string): boolean =>
 export const isError = (value: unknown): value is Error => value instanceof Error
 
 export const escapeSparqlStr = (str?: string): string => {
-  const sparqlEscapeRegExp = /[\t\n\r\b\f"'\\]/g
+  const escapeCharactersMap: Record<string, string> = {
+    '\t': '\\t',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\b': '\\b',
+    '\f': '\\f',
+    '"': '\\"',
+    "'": "\\'",
+    '\\': '\\\\'
+  }
 
-  const escapeCharactersMap = new Map([
-    ['\t', '\\t'],
-    ['\n', '\\n'],
-    ['\r', '\\r'],
-    ['\b', '\\b'],
-    ['\f', '\\f'],
-    ['"', '\\"'],
-    ["'", "\\'"],
-    ['\\', '\\\\']
-  ])
-
-  return str ? str.replace(sparqlEscapeRegExp, char => escapeCharactersMap.get(char) as string) : ''
+  return pipe(
+    str,
+    O.fromNullable,
+    O.map(s =>
+      pipe(
+        s,
+        Array.from,
+        A.map((char: string) => escapeCharactersMap[char] || char),
+        (chars: string[]) => chars.join('')
+      )
+    ),
+    O.getOrElse(() => '')
+  )
 }


### PR DESCRIPTION
This PR adds escaping for double quotes in the `FILTER` operator for dynamic literals that lead to a 400 http error.