### PR TITLE
Fix/Field input height

### DIFF
--- a/src/ui/component/field/field.scss
+++ b/src/ui/component/field/field.scss
@@ -43,6 +43,7 @@
       border: 0;
       border-radius: 6px;
       width: 100%;
+      height: inherit;
       padding: 0 0 7px;
       @include noto-sans(400);
       font-size: 16px;


### PR DESCRIPTION
Input fields scrolling area didn't filled the parent's height.

