### PR TITLE
feat(metadataFilling): add required fields validation

### DIFF
--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -5,17 +5,45 @@ import { DataSelection } from './steps/dataSelection/dataSelection'
 import { MetadataFilling } from './steps/metadataFilling/metadataFilling'
 import { Stepper } from '@/ui/component/stepper/stepper'
 import type { StepElement } from '@/ui/component/stepper/stepper'
+import { useAppStore } from '@/ui/store'
+import type { DatePickerValue, FormItem } from '@/ui/store/slice/shareData/shareData.slice'
 import '../i18n/index'
 import './shareDataset.scss'
 
 export const ShareDataset: FC = () => {
   const { t } = useTranslation('share')
-
+  const { form } = useAppStore(state => ({
+    form: state.shareData.form
+  }))
   const storageServiceSelection: StepElement = { id: 'step1', content: <ServiceStorageSelection /> }
   const dataSelection: StepElement = { id: 'step2', content: <DataSelection /> }
   const metadataFilling: StepElement = { id: 'step3', content: <MetadataFilling /> }
 
   const steps = [storageServiceSelection, dataSelection, metadataFilling]
+
+  const isFormItemFilled = (item: FormItem): boolean => {
+    switch (item.type) {
+      case 'text': {
+        return !!(item.value as unknown as string)
+      }
+      case 'select': {
+        return !!(item.value as unknown as string[]).length
+      }
+      case 'numeric': {
+        const numericField = item.value as unknown as number
+        return numericField === 0 || !!numericField
+      }
+      case 'date': {
+        const datePickerField = item.value as unknown as DatePickerValue
+        return !!datePickerField.from || !!datePickerField.to
+      }
+    }
+  }
+
+  const validateMetadataFillingStep = (): boolean => {
+    const requiredFields = form.filter(el => el.required)
+    return requiredFields.every(isFormItemFilled)
+  }
 
   return (
     <div className="okp4-dataverse-portal-share-dataset-page-main">

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -10,40 +10,45 @@ import type { DatePickerValue, FormItem } from '@/ui/store/slice/shareData/share
 import '../i18n/index'
 import './shareDataset.scss'
 
+const isFormItemFilled = (item: FormItem): boolean => {
+  switch (item.type) {
+    case 'text': {
+      return !!(item.value as unknown as string)
+    }
+    case 'select': {
+      return !!(item.value as unknown as string[]).length
+    }
+    case 'numeric': {
+      const numericField = item.value as unknown as number
+      return numericField === 0 || !!numericField
+    }
+    case 'date': {
+      const datePickerField = item.value as unknown as DatePickerValue
+      return !!datePickerField.from || !!datePickerField.to
+    }
+  }
+}
+
 export const ShareDataset: FC = () => {
   const { t } = useTranslation('share')
   const { form } = useAppStore(state => ({
     form: state.shareData.form
   }))
-  const storageServiceSelection: StepElement = { id: 'step1', content: <ServiceStorageSelection /> }
-  const dataSelection: StepElement = { id: 'step2', content: <DataSelection /> }
-  const metadataFilling: StepElement = { id: 'step3', content: <MetadataFilling /> }
-
-  const steps = [storageServiceSelection, dataSelection, metadataFilling]
-
-  const isFormItemFilled = (item: FormItem): boolean => {
-    switch (item.type) {
-      case 'text': {
-        return !!(item.value as unknown as string)
-      }
-      case 'select': {
-        return !!(item.value as unknown as string[]).length
-      }
-      case 'numeric': {
-        const numericField = item.value as unknown as number
-        return numericField === 0 || !!numericField
-      }
-      case 'date': {
-        const datePickerField = item.value as unknown as DatePickerValue
-        return !!datePickerField.from || !!datePickerField.to
-      }
-    }
-  }
 
   const validateMetadataFillingStep = (): boolean => {
     const requiredFields = form.filter(el => el.required)
     return requiredFields.every(isFormItemFilled)
   }
+
+  const storageServiceSelection: StepElement = { id: 'step1', content: <ServiceStorageSelection /> }
+  const dataSelection: StepElement = { id: 'step2', content: <DataSelection /> }
+  const metadataFilling: StepElement = {
+    id: 'step3',
+    content: <MetadataFilling />,
+    onValidate: validateMetadataFillingStep
+  }
+
+  const steps = [storageServiceSelection, dataSelection, metadataFilling]
 
   return (
     <div className="okp4-dataverse-portal-share-dataset-page-main">


### PR DESCRIPTION
This PR adds validation to step 3 of the share data: only the dataset title field is mandatory.

Validation remains in the UI for the time being, pending implementation at domain level with the appropriate business rules. 

🙏 For testing, just add an extra step after step 3 in order to see disabled button goes enabled after filling title only mandatory field.