### PR TITLE
Feat/sparql service category filter

### DIFF
--- a/src/domain/dataverse/command.ts
+++ b/src/domain/dataverse/command.ts
@@ -10,7 +10,9 @@ export type ByPropertyFilterInput = {
   property: FilterProperty
   value: string
 }
-export type ByServiceCategoryFilter = Option<string>
+
+export type ServiceCategoryVocab = 'Storage'
+export type ByServiceCategoryFilter = Option<ServiceCategoryVocab>
 
 export type Command = {
   // Load the dataverse elements from outside
@@ -21,7 +23,7 @@ export type Command = {
   setByTypeFilter: (newFilter: ByTypeFilterInput) => IO<void>
   // Filter the dataverse by an enumerated property
   setByPropertyFilter: (newFilter: ByPropertyFilterInput) => IO<void>
-  // Filter the dataverse by a service category name
+  // Filter the dataverse by a service category controlled vocabulary
   setByServiceCategoryFilter: (newFilter: ByServiceCategoryFilter) => IO<void>
   // Reset the by type filter
   resetByTypeFilter: () => IO<void>

--- a/src/domain/dataverse/command.ts
+++ b/src/domain/dataverse/command.ts
@@ -1,5 +1,6 @@
 import type { Task } from 'fp-ts/Task'
 import type { IO } from 'fp-ts/IO'
+import type { Option } from 'fp-ts/Option'
 
 type FilterProperty = 'title'
 
@@ -9,6 +10,7 @@ export type ByPropertyFilterInput = {
   property: FilterProperty
   value: string
 }
+export type ByServiceCategoryFilter = Option<string>
 
 export type Command = {
   // Load the dataverse elements from outside
@@ -19,8 +21,12 @@ export type Command = {
   setByTypeFilter: (newFilter: ByTypeFilterInput) => IO<void>
   // Filter the dataverse by an enumerated property
   setByPropertyFilter: (newFilter: ByPropertyFilterInput) => IO<void>
+  // Filter the dataverse by a service category name
+  setByServiceCategoryFilter: (newFilter: ByServiceCategoryFilter) => IO<void>
   // Reset the by type filter
   resetByTypeFilter: () => IO<void>
   // Reset the by property filter
   resetByPropertyFilter: () => IO<void>
+  // Reset the by service category filter
+  resetByServiceCategoryFilter: () => IO<void>
 }

--- a/src/domain/dataverse/domain.ts
+++ b/src/domain/dataverse/domain.ts
@@ -98,7 +98,7 @@ export const storeFactory = (
             limit: 20,
             hasNext: false,
             error: O.none,
-            filters: { byType: 'all', byProperty: null, byServiceCategory: O.none },
+            filters: { byType: 'all', byProperty: O.none, byServiceCategory: O.none },
             language: 'en'
           }))
         ),
@@ -112,11 +112,8 @@ export const storeFactory = (
             () => get().data.filters.byProperty,
             IO.map(
               flow(
-                O.fromNullable,
-                O.match(
-                  () => '',
-                  filter => filter.value
-                )
+                O.map(f => f.value),
+                O.getOrElse(() => '')
               )
             )
           ),
@@ -212,8 +209,8 @@ export const storeFactory = (
                   newFilter.value,
                   S.isEmpty,
                   B.match(
-                    () => newFilter,
-                    () => null
+                    () => O.some(newFilter),
+                    () => O.none
                   )
                 )
               }
@@ -237,7 +234,7 @@ export const storeFactory = (
               dataverse: [],
               filters: {
                 ...state.data.filters,
-                byProperty: null
+                byProperty: O.none
               }
             }
           })),

--- a/src/domain/dataverse/domain.ts
+++ b/src/domain/dataverse/domain.ts
@@ -16,6 +16,7 @@ import type { Dataverse } from './entity'
 import type { DataversePort } from './port'
 import type {
   ByPropertyFilterInput,
+  ByServiceCategoryFilter,
   ByTypeFilterInput,
   Command,
   DataverseElementType
@@ -97,7 +98,7 @@ export const storeFactory = (
             limit: 20,
             hasNext: false,
             error: O.none,
-            filters: { byType: 'all', byProperty: null },
+            filters: { byType: 'all', byProperty: null, byServiceCategory: O.none },
             language: 'en'
           }))
         ),
@@ -237,6 +238,28 @@ export const storeFactory = (
               filters: {
                 ...state.data.filters,
                 byProperty: null
+              }
+            }
+          })),
+        setByServiceCategoryFilter: (newFilter: ByServiceCategoryFilter) => () =>
+          set(state => ({
+            data: {
+              ...state.data,
+              dataverse: [],
+              filters: {
+                ...state.data.filters,
+                byServiceCategory: newFilter
+              }
+            }
+          })),
+        resetByServiceCategoryFilter: () => () =>
+          set(state => ({
+            data: {
+              ...state.data,
+              dataverse: [],
+              filters: {
+                ...state.data.filters,
+                byServiceCategory: O.none
               }
             }
           }))

--- a/src/domain/dataverse/port.ts
+++ b/src/domain/dataverse/port.ts
@@ -5,7 +5,7 @@ import type { Option } from 'fp-ts/Option'
 export type DataverseElementType = 'Zone' | 'Dataset' | 'Service'
 export type ByTypeQueryFilter = DataverseElementType[] | 'all'
 
-type ServiceCategoryVocab = 'Storage'
+export type ServiceCategoryVocab = 'Storage'
 export type ByServiceCategoryQueryFilter = Option<ServiceCategoryVocab>
 
 type FilterQueryProperty = 'title'

--- a/src/domain/dataverse/port.ts
+++ b/src/domain/dataverse/port.ts
@@ -9,10 +9,10 @@ export type ServiceCategoryVocab = 'Storage'
 export type ByServiceCategoryQueryFilter = Option<ServiceCategoryVocab>
 
 type FilterQueryProperty = 'title'
-export type ByPropertyQueryFilter = {
+export type ByPropertyQueryFilter = Option<{
   property: FilterQueryProperty
   value: string
-} | null
+}>
 
 export type RetrieveDataverseQueryFilters = {
   byType: ByTypeQueryFilter

--- a/src/domain/dataverse/port.ts
+++ b/src/domain/dataverse/port.ts
@@ -1,8 +1,12 @@
 import type * as TE from 'fp-ts/TaskEither'
 import type { DataverseElement } from '@/domain/dataverse/entity'
+import type { Option } from 'fp-ts/Option'
 
 export type DataverseElementType = 'Zone' | 'Dataset' | 'Service'
 export type ByTypeQueryFilter = DataverseElementType[] | 'all'
+
+type ServiceCategoryVocab = 'Storage'
+export type ByServiceCategoryQueryFilter = Option<ServiceCategoryVocab>
 
 type FilterQueryProperty = 'title'
 export type ByPropertyQueryFilter = {
@@ -13,6 +17,7 @@ export type ByPropertyQueryFilter = {
 export type RetrieveDataverseQueryFilters = {
   byType: ByTypeQueryFilter
   byProperty: ByPropertyQueryFilter
+  byServiceCategory: ByServiceCategoryQueryFilter
 }
 
 export type RetrieveDataverseResult = { data: DataverseElement[]; query: { hasNext: boolean } }

--- a/src/domain/dataverse/valueObject.ts
+++ b/src/domain/dataverse/valueObject.ts
@@ -11,9 +11,13 @@ export type ByPropertyFilter = {
   value: string
 } | null
 
+type ServiceCategoryVocab = 'Storage'
+export type ByServiceCategoryFilter = Option<ServiceCategoryVocab>
+
 type DataverseQueryFilters = {
   byType: ByTypeQueryFilter
   byProperty: ByPropertyFilter
+  byServiceCategory: ByServiceCategoryFilter
 }
 
 export type DataverseQuery = {

--- a/src/domain/dataverse/valueObject.ts
+++ b/src/domain/dataverse/valueObject.ts
@@ -6,10 +6,10 @@ type DataverseElementType = 'Zone' | 'Dataset' | 'Service'
 export type ByTypeQueryFilter = DataverseElementType[] | 'all'
 
 type FilterProperty = 'title'
-export type ByPropertyFilter = {
+export type ByPropertyFilter = Option<{
   property: FilterProperty
   value: string
-} | null
+}>
 
 type ServiceCategoryVocab = 'Storage'
 export type ByServiceCategoryFilter = Option<ServiceCategoryVocab>

--- a/src/infra/dataverse/sparql/sparqlGateway.ts
+++ b/src/infra/dataverse/sparql/sparqlGateway.ts
@@ -37,24 +37,24 @@ export const sparqlGateway: DataversePort = {
       PREFIX core: <https://ontology.okp4.space/core/>
       PREFIX owl: <http://www.w3.org/2002/07/owl#>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-      PREFIX serviceMetadata: <https://ontology.okp4.space/metadata/service/>
-      PREFIX datasetMetadata: <https://ontology.okp4.space/metadata/dataset/>
-      PREFIX zoneMetadata: <https://ontology.okp4.space/metadata/zone/>
+      PREFIX servicemetadata: <https://ontology.okp4.space/metadata/service/>
+      PREFIX datasetmetadata: <https://ontology.okp4.space/metadata/dataset/>
+      PREFIX zonemetadata: <https://ontology.okp4.space/metadata/zone/>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       PREFIX svccat: <https://ontology.okp4.space/thesaurus/service-category/> 
       SELECT DISTINCT ?id ?metadata ?title ?type ?publisher ?topic (COALESCE(?filteredPrefLabel, ?fallbackPrefLabel) as ?prefLabel)
       WHERE {
         {
           ?id rdf:type core:Service .
-          ?metadata rdf:type serviceMetadata:GeneralMetadata .
+          ?metadata rdf:type servicemetadata:GeneralMetadata .
           ?metadata core:hasCategory ?topic .
         } UNION {
           ?id rdf:type core:Dataset .
-          ?metadata rdf:type datasetMetadata:GeneralMetadata .
+          ?metadata rdf:type datasetmetadata:GeneralMetadata .
           ?metadata core:hasTopic ?topic .
         } UNION {          
           ?id rdf:type core:Zone .
-          ?metadata rdf:type zoneMetadata:GeneralMetadata .
+          ?metadata rdf:type zonemetadata:GeneralMetadata .
           ?metadata core:hasTopic ?topic .
         }
         ${byType === 'all' ? '' : `FILTER ( ${byTypeFilter(byType)} )`}

--- a/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
+++ b/src/ui/page/share/dataset/steps/serviceStorageSelection/serviceStorageSelection.tsx
@@ -49,7 +49,9 @@ export const ServiceStorageSelection: FC = () => {
     setLanguage,
     error,
     resetByTypeFilter,
-    resetByPropertyFilter
+    resetByPropertyFilter,
+    setByServiceCategoryFilter,
+    resetByServiceCategoryFilter
   } = useDataverseStore(state => ({
     loadDataverse: state.loadDataverse,
     dataverse: state.dataverse,
@@ -61,7 +63,9 @@ export const ServiceStorageSelection: FC = () => {
     setByTypeFilter: state.setByTypeFilter,
     error: state.error,
     resetByTypeFilter: state.resetByTypeFilter,
-    resetByPropertyFilter: state.resetByPropertyFilter
+    resetByPropertyFilter: state.resetByPropertyFilter,
+    setByServiceCategoryFilter: state.setByServiceCategoryFilter,
+    resetByServiceCategoryFilter: state.resetByServiceCategoryFilter
   }))
 
   const handleServiceSearch = useCallback(
@@ -127,10 +131,12 @@ export const ServiceStorageSelection: FC = () => {
   useEffect(() => {
     setLanguage(currentLng)()
     setByTypeFilter('Service')()
+    setByServiceCategoryFilter(O.some('Storage'))()
     loadDataverse()()
     return () => {
       resetByPropertyFilter()()
       resetByTypeFilter()()
+      resetByServiceCategoryFilter()()
     }
   }, [
     currentLng,
@@ -138,7 +144,9 @@ export const ServiceStorageSelection: FC = () => {
     setByTypeFilter,
     setLanguage,
     resetByTypeFilter,
-    resetByPropertyFilter
+    resetByPropertyFilter,
+    setByServiceCategoryFilter,
+    resetByServiceCategoryFilter
   ])
 
   return (


### PR DESCRIPTION
👉 This PR  aims to add a new filter regarding the `sparql` query onto the ontology database.

🧠 This new `byServiceCategoryFilter` allows to constraint the results for the share data - step1 (select a service storage) only to the objects in database which `serviceCategory` strictly equals `Storage` from the `vocabulary-category-service`.

🌶️ Technically, this PR adds 2 commands [`setByServiceCategoryFilter`- `resetByServiceCategoryFilter`] which return both `IO<void>` and add the desired filter onto the `sparql` gateway.

