### PR TITLE
style(metadataFilling): improve breakpoints display & add space

### DIFF
--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.scss
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.scss
@@ -44,12 +44,20 @@
           @include grid-item($colStart: 1, $colEnd: 6, $rowStart: auto, $rowEnd: auto);
           @include grid-container($colsNb: 2, $colGutter: 20px, $rowGutter: 16px);
           grid-template-rows: 42px 42px 214px 67px 67px;
+
+          @include use-breakpoints(('desktop')) {
+            @include grid-item($colStart: 1, $colEnd: 7, $rowStart: auto, $rowEnd: auto);
+          }
         }
 
         &.right {
           @include grid-item($colStart: 6, $colEnd: 11, $rowStart: auto, $rowEnd: auto);
           @include grid-container($colsNb: 1, $colGutter: 0, $rowGutter: 16px);
           grid-template-rows: 65px 65px 65px 205px;
+
+          @include use-breakpoints(('desktop')) {
+            @include grid-item($colStart: 7, $colEnd: 13, $rowStart: auto, $rowEnd: auto);
+          }
         }
 
         p {
@@ -57,6 +65,7 @@
           color: themed('text');
           font-size: 14px;
           line-height: 20px;
+          margin-bottom: 8px;
         }
       }
 


### PR DESCRIPTION
This PR fixes the step3 display in order to stick to figmas:
desktop and large desktop metadata filling take different spaces

desktop:
<img width="622" alt="Capture d’écran 2023-07-20 à 13 13 01" src="https://github.com/okp4/dataverse-portal/assets/35332974/42bfaa17-db18-4ec3-821c-5f3c97954df8">


large desktop:
<img width="821" alt="Capture d’écran 2023-07-20 à 13 13 08" src="https://github.com/okp4/dataverse-portal/assets/35332974/1ba47b34-4a5f-4fca-93a4-98d07d22cfac">

it also add some space between label and field to respect figmas.
