### PR TITLE
Feat/validation rules

### DIFF
--- a/src/domain/file/domain.ts
+++ b/src/domain/file/domain.ts
@@ -153,7 +153,7 @@ export const storeFactory = ({ initialState }: Partial<Options> = {}): StoreApi<
             )
           ),
         filesDescriptor: () => () => pipe(get().data, A.map(mapFileToFileDescriptor)),
-        hasStoredFile: () => () => !!get().data.length
+        hasStoredFiles: () => () => !!get().data.length
       })),
       {
         anonymousActionType: 'Aggregate',

--- a/src/domain/file/domain.ts
+++ b/src/domain/file/domain.ts
@@ -152,7 +152,8 @@ export const storeFactory = ({ initialState }: Partial<Options> = {}): StoreApi<
               () => IOE.of(undefined)
             )
           ),
-        filesDescriptor: () => () => pipe(get().data, A.map(mapFileToFileDescriptor))
+        filesDescriptor: () => () => pipe(get().data, A.map(mapFileToFileDescriptor)),
+        hasStoredFile: () => () => !!get().data.length
       })),
       {
         anonymousActionType: 'Aggregate',

--- a/src/domain/file/query.ts
+++ b/src/domain/file/query.ts
@@ -15,4 +15,6 @@ export type FilesDescriptor = FileDescriptor[]
 export type Query = {
   // Get the base properties of in memory files.
   filesDescriptor: () => IO<FilesDescriptor>
+  // Tell if, at least, one file is stored
+  hasStoredFile: () => IO<boolean>
 }

--- a/src/domain/file/query.ts
+++ b/src/domain/file/query.ts
@@ -16,5 +16,5 @@ export type Query = {
   // Get the base properties of in memory files.
   filesDescriptor: () => IO<FilesDescriptor>
   // Tell if, at least, one file is stored
-  hasStoredFile: () => IO<boolean>
+  hasStoredFiles: () => IO<boolean>
 }

--- a/src/domain/file/test/removeFile.spec.ts
+++ b/src/domain/file/test/removeFile.spec.ts
@@ -16,7 +16,7 @@ type Data = {
   fileToRemove: FileId
   preloadedState: FileDomain.Options
   expectedFilesDescriptor: FilesDescriptor
-  expectedHasStoredFile: boolean
+  expectedHasStoredFiles: boolean
   error?: ResourceNotFoundError
 }
 
@@ -59,19 +59,19 @@ describe('Remove a file from memory', () => {
     }))
 
   describe.each`
-    preloadedState                                | fileToRemove     | expectedFilesDescriptor           | expectedHasStoredFile | error
-    ${undefined}                                  | ${''}            | ${[]}                             | ${false}              | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${''}            | ${expectFilesDescriptor([file1])} | ${true}               | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${fileToRemove1} | ${[]}                             | ${false}              | ${undefined}
-    ${{ initialState: { data: [file1, file2] } }} | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}               | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}               | ${ResourceNotFoundError(fileToRemove2)}
+    preloadedState                                | fileToRemove     | expectedFilesDescriptor           | expectedHasStoredFiles | error
+    ${undefined}                                  | ${''}            | ${[]}                             | ${false}               | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${''}            | ${expectFilesDescriptor([file1])} | ${true}                | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${fileToRemove1} | ${[]}                             | ${false}               | ${undefined}
+    ${{ initialState: { data: [file1, file2] } }} | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}                | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}                | ${ResourceNotFoundError(fileToRemove2)}
   `(
     `Given that there are a file to remove with a given id <$fileToRemove>`,
     ({
       preloadedState,
       fileToRemove,
       expectedFilesDescriptor,
-      expectedHasStoredFile,
+      expectedHasStoredFiles,
       error
     }: Data): void => {
       const { store } = initStore(preloadedState)
@@ -82,7 +82,7 @@ describe('Remove a file from memory', () => {
         )}`, () => {
           const result = store.getState().removeFile(fileToRemove)()
           expect(store.getState().filesDescriptor()()).toStrictEqual(expectedFilesDescriptor)
-          expect(store.getState().hasStoredFile()()).toBe(expectedHasStoredFile)
+          expect(store.getState().hasStoredFiles()()).toBe(expectedHasStoredFiles)
           expect(result).toBeEither()
           if (error) {
             expect(result).toBeLeft()

--- a/src/domain/file/test/removeFile.spec.ts
+++ b/src/domain/file/test/removeFile.spec.ts
@@ -16,6 +16,7 @@ type Data = {
   fileToRemove: FileId
   preloadedState: FileDomain.Options
   expectedFilesDescriptor: FilesDescriptor
+  expectedHasStoredFile: boolean
   error?: ResourceNotFoundError
 }
 
@@ -58,15 +59,21 @@ describe('Remove a file from memory', () => {
     }))
 
   describe.each`
-    preloadedState                                | fileToRemove     | expectedFilesDescriptor           | error
-    ${undefined}                                  | ${''}            | ${[]}                             | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${''}            | ${expectFilesDescriptor([file1])} | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${fileToRemove1} | ${[]}                             | ${undefined}
-    ${{ initialState: { data: [file1, file2] } }} | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${undefined}
-    ${{ initialState: { data: [file1] } }}        | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${ResourceNotFoundError(fileToRemove2)}
+    preloadedState                                | fileToRemove     | expectedFilesDescriptor           | expectedHasStoredFile | error
+    ${undefined}                                  | ${''}            | ${[]}                             | ${false}              | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${''}            | ${expectFilesDescriptor([file1])} | ${true}               | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${fileToRemove1} | ${[]}                             | ${false}              | ${undefined}
+    ${{ initialState: { data: [file1, file2] } }} | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}               | ${undefined}
+    ${{ initialState: { data: [file1] } }}        | ${fileToRemove2} | ${expectFilesDescriptor([file1])} | ${true}               | ${ResourceNotFoundError(fileToRemove2)}
   `(
     `Given that there are a file to remove with a given id <$fileToRemove>`,
-    ({ preloadedState, fileToRemove, expectedFilesDescriptor, error }: Data): void => {
+    ({
+      preloadedState,
+      fileToRemove,
+      expectedFilesDescriptor,
+      expectedHasStoredFile,
+      error
+    }: Data): void => {
       const { store } = initStore(preloadedState)
 
       describe('When removing file', () => {
@@ -75,6 +82,7 @@ describe('Remove a file from memory', () => {
         )}`, () => {
           const result = store.getState().removeFile(fileToRemove)()
           expect(store.getState().filesDescriptor()()).toStrictEqual(expectedFilesDescriptor)
+          expect(store.getState().hasStoredFile()()).toBe(expectedHasStoredFile)
           expect(result).toBeEither()
           if (error) {
             expect(result).toBeLeft()

--- a/src/domain/file/test/storeFiles.spec.ts
+++ b/src/domain/file/test/storeFiles.spec.ts
@@ -16,6 +16,7 @@ type Data = {
   filesToStore: StoreFilesInput
   preloadedState: FileDomain.Options
   expectedFilesDescriptor: FilesDescriptor
+  expectedHasStoredFile: boolean
   error?: ResourceAlreadyExistsError
 }
 
@@ -67,16 +68,22 @@ describe('Store files in memory', () => {
     }))
 
   describe.each`
-    preloadedState                         | filesToStore                    | expectedFilesDescriptor                  | error
-    ${undefined}                           | ${[]}                           | ${[]}                                    | ${undefined}
-    ${{ initialState: { data: [file1] } }} | ${[]}                           | ${expectFilesDescriptor([file1])}        | ${undefined}
-    ${undefined}                           | ${[fileToStore1]}               | ${expectFilesDescriptor([file1])}        | ${undefined}
-    ${undefined}                           | ${[fileToStore1, fileToStore2]} | ${expectFilesDescriptor([file1, file2])} | ${undefined}
-    ${{ initialState: { data: [file1] } }} | ${[fileToStore3]}               | ${expectFilesDescriptor([file1])}        | ${ResourceAlreadyExistsError([fileToStore3.id])}
-    ${undefined}                           | ${[fileToStore1, fileToStore3]} | ${[]}                                    | ${ResourceAlreadyExistsError([fileToStore1.id, fileToStore3.id])}
+    preloadedState                         | filesToStore                    | expectedFilesDescriptor                  | expectedHasStoredFile | error
+    ${undefined}                           | ${[]}                           | ${[]}                                    | ${false}              | ${undefined}
+    ${{ initialState: { data: [file1] } }} | ${[]}                           | ${expectFilesDescriptor([file1])}        | ${true}               | ${undefined}
+    ${undefined}                           | ${[fileToStore1]}               | ${expectFilesDescriptor([file1])}        | ${true}               | ${undefined}
+    ${undefined}                           | ${[fileToStore1, fileToStore2]} | ${expectFilesDescriptor([file1, file2])} | ${true}               | ${undefined}
+    ${{ initialState: { data: [file1] } }} | ${[fileToStore3]}               | ${expectFilesDescriptor([file1])}        | ${true}               | ${ResourceAlreadyExistsError([fileToStore3.id])}
+    ${undefined}                           | ${[fileToStore1, fileToStore3]} | ${[]}                                    | ${false}              | ${ResourceAlreadyExistsError([fileToStore1.id, fileToStore3.id])}
   `(
     `Given that there are $filesToStore.length file(s) to store`,
-    ({ preloadedState, filesToStore, expectedFilesDescriptor, error }: Data): void => {
+    ({
+      preloadedState,
+      filesToStore,
+      expectedFilesDescriptor,
+      expectedHasStoredFile,
+      error
+    }: Data): void => {
       const { store } = initStore(preloadedState)
 
       describe('When storing files', () => {
@@ -85,6 +92,7 @@ describe('Store files in memory', () => {
         )}`, () => {
           const result = store.getState().storeFiles(filesToStore)()
           expect(store.getState().filesDescriptor()()).toStrictEqual(expectedFilesDescriptor)
+          expect(store.getState().hasStoredFile()()).toBe(expectedHasStoredFile)
           expect(result).toBeEither()
           if (error) {
             expect(result).toBeLeft()

--- a/src/domain/file/test/storeFiles.spec.ts
+++ b/src/domain/file/test/storeFiles.spec.ts
@@ -16,7 +16,7 @@ type Data = {
   filesToStore: StoreFilesInput
   preloadedState: FileDomain.Options
   expectedFilesDescriptor: FilesDescriptor
-  expectedHasStoredFile: boolean
+  expectedHasStoredFiles: boolean
   error?: ResourceAlreadyExistsError
 }
 
@@ -68,20 +68,20 @@ describe('Store files in memory', () => {
     }))
 
   describe.each`
-    preloadedState                         | filesToStore                    | expectedFilesDescriptor                  | expectedHasStoredFile | error
-    ${undefined}                           | ${[]}                           | ${[]}                                    | ${false}              | ${undefined}
-    ${{ initialState: { data: [file1] } }} | ${[]}                           | ${expectFilesDescriptor([file1])}        | ${true}               | ${undefined}
-    ${undefined}                           | ${[fileToStore1]}               | ${expectFilesDescriptor([file1])}        | ${true}               | ${undefined}
-    ${undefined}                           | ${[fileToStore1, fileToStore2]} | ${expectFilesDescriptor([file1, file2])} | ${true}               | ${undefined}
-    ${{ initialState: { data: [file1] } }} | ${[fileToStore3]}               | ${expectFilesDescriptor([file1])}        | ${true}               | ${ResourceAlreadyExistsError([fileToStore3.id])}
-    ${undefined}                           | ${[fileToStore1, fileToStore3]} | ${[]}                                    | ${false}              | ${ResourceAlreadyExistsError([fileToStore1.id, fileToStore3.id])}
+    preloadedState                         | filesToStore                    | expectedFilesDescriptor                  | expectedHasStoredFiles | error
+    ${undefined}                           | ${[]}                           | ${[]}                                    | ${false}               | ${undefined}
+    ${{ initialState: { data: [file1] } }} | ${[]}                           | ${expectFilesDescriptor([file1])}        | ${true}                | ${undefined}
+    ${undefined}                           | ${[fileToStore1]}               | ${expectFilesDescriptor([file1])}        | ${true}                | ${undefined}
+    ${undefined}                           | ${[fileToStore1, fileToStore2]} | ${expectFilesDescriptor([file1, file2])} | ${true}                | ${undefined}
+    ${{ initialState: { data: [file1] } }} | ${[fileToStore3]}               | ${expectFilesDescriptor([file1])}        | ${true}                | ${ResourceAlreadyExistsError([fileToStore3.id])}
+    ${undefined}                           | ${[fileToStore1, fileToStore3]} | ${[]}                                    | ${false}               | ${ResourceAlreadyExistsError([fileToStore1.id, fileToStore3.id])}
   `(
     `Given that there are $filesToStore.length file(s) to store`,
     ({
       preloadedState,
       filesToStore,
       expectedFilesDescriptor,
-      expectedHasStoredFile,
+      expectedHasStoredFiles,
       error
     }: Data): void => {
       const { store } = initStore(preloadedState)
@@ -92,7 +92,7 @@ describe('Store files in memory', () => {
         )}`, () => {
           const result = store.getState().storeFiles(filesToStore)()
           expect(store.getState().filesDescriptor()()).toStrictEqual(expectedFilesDescriptor)
-          expect(store.getState().hasStoredFile()()).toBe(expectedHasStoredFile)
+          expect(store.getState().hasStoredFiles()()).toBe(expectedHasStoredFiles)
           expect(result).toBeEither()
           if (error) {
             expect(result).toBeLeft()

--- a/src/ui/component/stepper/stepper.tsx
+++ b/src/ui/component/stepper/stepper.tsx
@@ -9,7 +9,7 @@ import './stepper.scss'
 
 export type StepElement = Optional<Omit<Step, 'order'>, 'status'> & {
   content: JSX.Element
-  onValidate?: () => boolean
+  validate?: () => boolean
 }
 
 type StepperProps = {
@@ -45,7 +45,7 @@ export const Stepper: FC<StepperProps> = ({ steps: stepElements }) => {
       </TransitionGroup>
 
       <StepperActions
-        isActiveStepValid={activeStepElement.onValidate?.() ?? true}
+        isActiveStepValid={activeStepElement.validate?.() ?? true}
         isFirstStep={activeStep.order === 0}
         isLastStep={activeStep.order === steps.length - 1}
         nextStep={nextStep}

--- a/src/ui/hook/useStepper.ts
+++ b/src/ui/hook/useStepper.ts
@@ -24,7 +24,7 @@ export type Step = {
   id: StepId
   order: number
   status: StepStatus
-  onValidate?: () => boolean
+  validate?: () => boolean
 }
 
 export const findStep = (steps: Step[], stepId?: StepId): Step =>

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -15,8 +15,8 @@ export const ShareDataset: FC = () => {
   const { storageServiceId } = useAppStore(store => ({
     storageServiceId: store.shareData.storageServiceId
   }))
-  const { hasStoredFile } = useFileStore(store => ({
-    hasStoredFile: store.hasStoredFile
+  const { hasStoredFiles } = useFileStore(store => ({
+    hasStoredFiles: store.hasStoredFiles
   }))
 
   const storageServiceSelection: StepElement = {
@@ -27,7 +27,7 @@ export const ShareDataset: FC = () => {
   const dataSelection: StepElement = {
     id: 'step2',
     content: <DataSelection />,
-    validate: () => hasStoredFile()()
+    validate: () => hasStoredFiles()()
   }
   const metadataFilling: StepElement = { id: 'step3', content: <MetadataFilling /> }
 

--- a/src/ui/page/share/dataset/shareDataset.tsx
+++ b/src/ui/page/share/dataset/shareDataset.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import * as O from 'fp-ts/Option'
 import { ServiceStorageSelection } from './steps/serviceStorageSelection/serviceStorageSelection'
 import { DataSelection } from './steps/dataSelection/dataSelection'
 import { MetadataFilling } from './steps/metadataFilling/metadataFilling'
@@ -7,12 +8,27 @@ import { Stepper } from '@/ui/component/stepper/stepper'
 import type { StepElement } from '@/ui/component/stepper/stepper'
 import '../i18n/index'
 import './shareDataset.scss'
+import { useAppStore, useFileStore } from '@/ui/store'
 
 export const ShareDataset: FC = () => {
   const { t } = useTranslation('share')
+  const { storageServiceId } = useAppStore(store => ({
+    storageServiceId: store.shareData.storageServiceId
+  }))
+  const { hasStoredFile } = useFileStore(store => ({
+    hasStoredFile: store.hasStoredFile
+  }))
 
-  const storageServiceSelection: StepElement = { id: 'step1', content: <ServiceStorageSelection /> }
-  const dataSelection: StepElement = { id: 'step2', content: <DataSelection /> }
+  const storageServiceSelection: StepElement = {
+    id: 'step1',
+    content: <ServiceStorageSelection />,
+    validate: () => O.isSome(storageServiceId)
+  }
+  const dataSelection: StepElement = {
+    id: 'step2',
+    content: <DataSelection />,
+    validate: () => hasStoredFile()()
+  }
   const metadataFilling: StepElement = { id: 'step3', content: <MetadataFilling /> }
 
   const steps = [storageServiceSelection, dataSelection, metadataFilling]


### PR DESCRIPTION
👉 This PR mainly brings the validation rules for steps 1 and 2.

🧠 Validation rules are based upon `shareDataSlice` from `appStore` for the transients states and upon the `file` domain for the drag and drop part

😎 This PR brings two further elements: 

- a new `hasStoredFile` query from the `file` domain which, in a trivial way, says if at least one file has been stored
- a little refactor about the  stepper `onValidate` method that has been renamed to `validate`, following the @ccamel 's [comment](https://github.com/okp4/dataverse-portal/pull/387#discussion_r1270337497) on previous [PR](https://github.com/okp4/dataverse-portal/pull/387).

🧪 `file` domain test suite has been updated to cover the new `hasStoredFile` query