### PR TITLE
feat(list): add container classname to classes

### DIFF
--- a/src/ui/component/list/list.tsx
+++ b/src/ui/component/list/list.tsx
@@ -26,12 +26,15 @@ type ListProps = {
   items: Item[]
   classes?: {
     main?: string
+    container?: string
   }
 }
 
 export const List: FC<ListProps> = ({ items, classes }) => (
   <ul className={classNames('okp4-dataverse-portal-list-main', classes?.main)}>
-    <TransitionGroup className="okp4-dataverse-portal-list-container">
+    <TransitionGroup
+      className={classNames('okp4-dataverse-portal-list-container', classes?.container)}
+    >
       {items.map(({ leftElement, rightElement, content, className, id, onClick }) => (
         <CSSTransition classNames="transition" key={id} timeout={400}>
           <li


### PR DESCRIPTION
This PR aims to add a container classname to the `List` class property.
Thanks to this, we'll be able to style the list and, for our feature, to handle different gaps between list items (as it is the case in step 3 & step 4).