### PR TITLE
Feat/Optional field's onChange handler

### DIFF
--- a/src/ui/component/field/field.tsx
+++ b/src/ui/component/field/field.tsx
@@ -6,7 +6,7 @@ import './field.scss'
 type FieldProps = {
   id: string
   label?: string
-  onChange: (value: string) => void
+  onChange?: (value: string) => void
   value?: string
   type?: 'text' | 'number'
   error?: string
@@ -44,7 +44,7 @@ export const Field: FC<FieldProps> = ({
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-      onChange(e.target.value)
+      onChange?.(e.target.value)
     },
     [onChange]
   )
@@ -67,7 +67,7 @@ export const Field: FC<FieldProps> = ({
     id,
     name: id,
     onBlur: handleBlur,
-    onChange: handleChange,
+    ...(onChange && { onChange: handleChange }),
     onFocus: handleFocus,
     readOnly: readonly,
     required,


### PR DESCRIPTION
This PR makes the field's `onChange` handler optional, when a field is read-only or disabled, and the user doesn't need to interact with it.
This might happens on several pages, e. g. share data summary (step 4).