### PR TITLE
Feat/numerical field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
+    "react-number-format": "^5.2.2",
     "react-router-dom": "^6.14.1",
     "react-transition-group": "^4.4.5",
     "short-uuid": "^4.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   react-markdown:
     specifier: ^8.0.7
     version: 8.0.7(@types/react@18.2.15)(react@18.2.0)
+  react-number-format:
+    specifier: ^5.2.2
+    version: 5.2.2(react-dom@18.2.0)(react@18.2.0)
   react-router-dom:
     specifier: ^6.14.1
     version: 6.14.1(react-dom@18.2.0)(react@18.2.0)
@@ -5645,6 +5648,17 @@ packages:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /react-number-format@5.2.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wCh64Z1HCwXcO2dbgkeYIaB+Rmp/fcsH8kAeRtUkc46dv1pIrgDjie2WkOqKBw8YqyqhwNdYgNFNQuuY+iGJ/g==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-router-dom@6.14.1(react-dom@18.2.0)(react@18.2.0):

--- a/src/ui/component/field/field.tsx
+++ b/src/ui/component/field/field.tsx
@@ -1,8 +1,9 @@
-import { type FC, type ChangeEvent, useCallback, useState, useRef } from 'react'
+import { type FC, type ChangeEvent, useCallback, useState } from 'react'
 import classNames from 'classnames'
 import type { NumericFormatProps } from 'react-number-format'
 import { NumericFormat } from 'react-number-format'
 import { Icon } from '@/ui/component/icon/icon'
+import { omit } from '@/util/util'
 import './field.scss'
 
 type InputProps = Omit<NumericFormatProps, 'type'> & {
@@ -24,6 +25,17 @@ type FieldProps = InputProps & {
   leftElement?: JSX.Element
   rightElement?: JSX.Element
 }
+
+type NonInputKeys = keyof Omit<FieldProps, keyof InputProps>
+const nonInputKeys: NonInputKeys[] = [
+  'label',
+  'type',
+  'error',
+  'multiline',
+  'resizable',
+  'leftElement',
+  'rightElement'
+]
 
 // eslint-disable-next-line max-lines-per-function
 export const Field: FC<FieldProps> = props => {
@@ -81,7 +93,7 @@ export const Field: FC<FieldProps> = props => {
   }
 
   const numericInputProps = {
-    ...props,
+    ...omit(props, nonInputKeys),
     ...textFieldInputProps
   }
 

--- a/src/ui/component/field/field.tsx
+++ b/src/ui/component/field/field.tsx
@@ -40,7 +40,6 @@ export const Field: FC<FieldProps> = ({
   const [focused, setFocused] = useState(false)
   const handleFocus = useCallback((): void => setFocused(true), [])
   const handleBlur = useCallback((): void => setFocused(false), [])
-  const textInputRef = useRef(null)
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
@@ -71,7 +70,6 @@ export const Field: FC<FieldProps> = ({
     onFocus: handleFocus,
     readOnly: readonly,
     required,
-    ref: textInputRef,
     value,
     placeholder
   }

--- a/src/ui/component/field/field.tsx
+++ b/src/ui/component/field/field.tsx
@@ -6,7 +6,7 @@ import './field.scss'
 type FieldProps = {
   id: string
   label?: string
-  onChange?: (value: string) => void
+  onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
   value?: string
   type?: 'text' | 'number'
   error?: string
@@ -42,8 +42,8 @@ export const Field: FC<FieldProps> = ({
   const handleBlur = useCallback((): void => setFocused(false), [])
 
   const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-      onChange?.(e.target.value)
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+      onChange?.(event)
     },
     [onChange]
   )

--- a/src/ui/component/field/field.tsx
+++ b/src/ui/component/field/field.tsx
@@ -1,19 +1,24 @@
 import { type FC, type ChangeEvent, useCallback, useState, useRef } from 'react'
 import classNames from 'classnames'
+import type { NumericFormatProps } from 'react-number-format'
+import { NumericFormat } from 'react-number-format'
 import { Icon } from '@/ui/component/icon/icon'
 import './field.scss'
 
-type FieldProps = {
+type InputProps = Omit<NumericFormatProps, 'type'> & {
   id: string
-  label?: string
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
   value?: string
-  type?: 'text' | 'number'
-  error?: string
   placeholder?: string
   required?: boolean
   disabled?: boolean
   readonly?: boolean
+}
+
+type FieldProps = InputProps & {
+  label?: string
+  type?: 'text' | 'numeric'
+  error?: string
   multiline?: boolean
   resizable?: boolean
   leftElement?: JSX.Element
@@ -21,22 +26,23 @@ type FieldProps = {
 }
 
 // eslint-disable-next-line max-lines-per-function
-export const Field: FC<FieldProps> = ({
-  id,
-  label,
-  onChange,
-  value,
-  type = 'text',
-  error,
-  placeholder,
-  required = false,
-  disabled = false,
-  readonly = false,
-  multiline = false,
-  resizable = false,
-  leftElement,
-  rightElement
-}) => {
+export const Field: FC<FieldProps> = props => {
+  const {
+    id,
+    label,
+    onChange,
+    value,
+    type = 'text',
+    error,
+    placeholder,
+    required = false,
+    disabled = false,
+    readonly = false,
+    multiline = false,
+    resizable = false,
+    leftElement,
+    rightElement
+  } = props
   const [focused, setFocused] = useState(false)
   const handleFocus = useCallback((): void => setFocused(true), [])
   const handleBlur = useCallback((): void => setFocused(false), [])
@@ -74,6 +80,11 @@ export const Field: FC<FieldProps> = ({
     placeholder
   }
 
+  const numericInputProps = {
+    ...props,
+    ...textFieldInputProps
+  }
+
   return (
     <div className={classNames(textFieldClassNames, 'okp4-dataverse-portal-field-main')}>
       {leftElement && (
@@ -84,10 +95,12 @@ export const Field: FC<FieldProps> = ({
         </div>
       )}
 
-      {multiline ? (
+      {type === 'numeric' ? (
+        <NumericFormat {...numericInputProps} type="text" />
+      ) : multiline ? (
         <textarea {...textFieldInputProps} />
       ) : (
-        <input {...textFieldInputProps} type={type} />
+        <input {...textFieldInputProps} />
       )}
 
       {rightElement && (

--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines-per-function */
+import type { ChangeEvent } from 'react'
 import { useEffect, useMemo, useCallback, type FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import * as IOO from 'fp-ts/IOOption'
@@ -65,8 +66,8 @@ export const MetadataFilling: FC = () => {
   const formSides = ['left', 'right']
 
   const handleFieldValueChange = useCallback(
-    (id: string) => (value: string) => {
-      setFormItemValue({ id, value })()
+    (id: string) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFormItemValue({ id, value: event.target.value })()
     },
     [setFormItemValue]
   )

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,4 +1,4 @@
-import { getURILastElement, isError, isSubstringOf } from './util'
+import { getURILastElement, isError, isSubstringOf, omit } from './util'
 import * as O from 'fp-ts/Option'
 
 type Data = {
@@ -70,5 +70,31 @@ describe('isError guard function', () => {
         expect(result).toStrictEqual(expectedResult)
       })
     })
+  })
+})
+
+describe('omit function', () => {
+  it('returns an object with the specified properties omitted', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    const result = omit(obj, ['b', 'c'])
+    expect(result).toEqual({ a: 1 })
+  })
+
+  it('returns the same object when there are no properties to omit', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    const result = omit(obj, [])
+    expect(result).toEqual(obj)
+  })
+
+  it('returns an empty object when all properties are omitted', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    const result = omit(obj, ['a', 'b', 'c'])
+    expect(result).toEqual({})
+  })
+
+  it('does not mutate the original object', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    omit(obj, ['a'])
+    expect(obj).toEqual({ a: 1, b: 2, c: 3 })
   })
 })

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -37,3 +37,11 @@ export const isSubstringOf = (substring: string, source: string): boolean =>
   pipe(source, S.toLowerCase, S.includes(S.toLowerCase(substring)))
 
 export const isError = (value: unknown): value is Error => value instanceof Error
+
+export const omit = <T extends string | number | symbol>(
+  props: Partial<Record<T, unknown>>,
+  omitProps: T[]
+): Partial<Record<T, unknown>> =>
+  Object.fromEntries(
+    Object.entries(props).filter(([key]) => !omitProps.includes(key as T))
+  ) as Partial<Record<T, unknown>>


### PR DESCRIPTION
## Numerical field
This PR display localised numbers for numerical fields, according to the defined numerical inputs rules from the design system.
When the user is typing, the field is be formatted according to the provided locale (`lang`), separator can be overridden using `thousandSeparator` and `decimalSeparator` props.

In order to comply with product requirement for Fees input, we define the narrow no-break space as thousands separator and full stop as decimal separator. Also, `decimalScale` allow to get the expected number for the KNOW token.

### Usage
```ts
<Field
  allowLeadingZeros={false}
  allowNegative={false}
  decimalScale={APP_ENV.chains[0].feeCurrencies[0].coinDecimals} // 6
  decimalSeparator="."
  id="fees"
  lang="fr-FR" 
  onChange={handleChange}
  placeholder="0"
  rightElement={<span>{APP_ENV.chains[0].currencies[0].coinDenom}</span>} // KNOW
  thousandSeparator=" " // narrow non-breaking spaces
  type="numeric" // 👈 define field type for numeric input
  value={value}
/>
```

