### PR TITLE
Feat/floating and orientation behavior for Collapsible content

### DIFF
--- a/src/ui/component/collapsible/collapsible.scss
+++ b/src/ui/component/collapsible/collapsible.scss
@@ -1,19 +1,28 @@
 @import '@/ui/style/theme.scss';
 
+.okp4-dataverse-portal-collapsible-main {
+  display: flex;
+  flex-direction: column;
+
+  &.up {
+    flex-direction: column-reverse;
+  }
+}
+
 .okp4-dataverse-portal-collapsible-trigger-icon {
   @include with-theme {
     display: flex;
     justify-content: center;
     align-items: center;
     transition: transform 200ms ease-out;
-    
+
     &.flipped {
       transform: rotate(180deg);
     }
 
     path {
-      fill: themed("text");
-      stroke: themed("text");
+      fill: themed('text');
+      stroke: themed('text');
     }
   }
 }
@@ -29,17 +38,32 @@
 
 .okp4-dataverse-portal-collapsible-content {
   overflow: hidden;
+
+  &.floating {
+    position: absolute;
+    z-index: 1;
+
+    &.up {
+      top: 0;
+      transform: translateY(-100%);
+    }
+
+    &.down {
+      top: 100%;
+    }
+  }
+  
 }
 
 .okp4-dataverse-portal-collapsible-content[data-state='open'] {
-  animation: slideDown 300ms ease-out;
+  animation: expand 300ms ease-out;
 }
 
 .okp4-dataverse-portal-collapsible-content[data-state='closed'] {
-  animation: slideUp 300ms ease-out;
+  animation: collapse 300ms ease-out;
 }
 
-@keyframes slideDown {
+@keyframes expand {
   from {
     height: 0;
     width: var(--okp4-collapsible-trigger-initial-width);
@@ -51,7 +75,7 @@
   }
 }
 
-@keyframes slideUp {
+@keyframes collapse {
   from {
     height: var(--radix-collapsible-content-height);
     width: var(--radix-collapsible-content-width);

--- a/src/ui/component/collapsible/collapsible.tsx
+++ b/src/ui/component/collapsible/collapsible.tsx
@@ -15,6 +15,8 @@ type CollapsibleProps = {
   triggerClassName?: string
   iconName?: IconName
   onOpenChange?: (isOpened: boolean) => void
+  floatingContent?: boolean
+  contentExpandDirection?: 'up' | 'down'
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -26,7 +28,9 @@ export const Collapsible: FC<CollapsibleProps> = ({
   rootClassName,
   triggerClassName,
   iconName = 'chevron',
-  onOpenChange
+  onOpenChange,
+  floatingContent = false,
+  contentExpandDirection = 'down'
 }) => {
   const [triggerInitWidth, setTriggerInitWidth] = useState<number>(0)
   const [isOpen, setIsOpen] = useState(open)
@@ -40,7 +44,11 @@ export const Collapsible: FC<CollapsibleProps> = ({
 
   return (
     <RCollapsible.Root
-      className={rootClassName}
+      className={classNames(
+        'okp4-dataverse-portal-collapsible-main',
+        rootClassName,
+        contentExpandDirection
+      )}
       onOpenChange={onOpenChange ?? setIsOpen}
       open={openState}
     >
@@ -52,9 +60,7 @@ export const Collapsible: FC<CollapsibleProps> = ({
         <div
           className={classNames(
             'okp4-dataverse-portal-collapsible-trigger-icon',
-            {
-              flipped: openState
-            },
+            { flipped: openState },
             `${triggerClassName}-icon`
           )}
         >
@@ -62,7 +68,9 @@ export const Collapsible: FC<CollapsibleProps> = ({
         </div>
       </RCollapsible.Trigger>
       <RCollapsible.Content
-        className={classNames('okp4-dataverse-portal-collapsible-content', contentClassName)}
+        className={classNames('okp4-dataverse-portal-collapsible-content', contentClassName, {
+          [`floating ${contentExpandDirection}`]: floatingContent
+        })}
         style={{
           // Copying the behaviour of the Radix-ui collapsible, for the slide animations
           ['--okp4-collapsible-trigger-initial-width' as string]: `${triggerInitWidth}px`


### PR DESCRIPTION
This PR allow Collapsible component to expand it's content:
- `up` or `down` (default `down`) according to the `contentExpandDirection` props.
- in a floating way (default `false`) according to the `floating` props.

Collapsible content orientation or floating behaviour can vary according to context (filers, expandable buttons, dropdown...).
This PR is a part of a refactoring of the dropdown UI PR #413. The goal is to delegate the behaviours related to the collapsible content to it's related component, `Collapsible`.