### PR TITLE
Feat/add modal

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,6 +30,7 @@ const App: FC = () => {
           </div>
         </div>
       </div>
+      <div id="modal" />
       <Notification />
     </div>
   )

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,7 +30,7 @@ const App: FC = () => {
           </div>
         </div>
       </div>
-      <div id="modal" />
+      <div id="modal-root" />
       <Notification />
     </div>
   )

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -20,31 +20,55 @@
       border-radius: 12px;
       box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.06);
       padding: 30px 12px 19px 33px;
-      width: 313px;
       display: flex;
       flex-direction: column;
       align-items: center;
       z-index: 2;
+      opacity: 1;
+      transform: scale(1);
+      transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 
-      @include use-breakpoints(('mobile', 'tablet')) {
-        width: 307px;
+      .okp4-dataverse-portal-modal-content {
+        @include columns-with-gap(30px);
+        color: themed('text');
+        padding-right: 14px;
       }
 
-      .okp4-dataverse-portal-modal-wrapper {
-        max-height: 605px;
-        overflow-y: auto;
-
-        .okp4-dataverse-portal-modal-content {
-          color: themed('text');
-          @include columns-with-gap(30px);
-          padding-right: 14px;
+      &.zoom {
+        &.open {
+          animation: zoomIn 2s ease-in-out;
         }
       }
 
-      .okp4-dataverse-portal-modal-button {
-        margin-top: 40px;
-        width: 120px;
+      &.zoom {
+        &:not(.open) {
+          animation: zoomOut 2s ease-in-out;
+        }
       }
     }
+  }
+}
+
+@keyframes zoomIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes zoomOut {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(0.8);
   }
 }

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -9,7 +9,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.6000000238418579);
+    background-color: rgba(0, 0, 0, 0.6);
     z-index: 999;
 
     &.centered {
@@ -22,15 +22,10 @@
       background: themed('modal-background');
       border-radius: 12px;
       box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.06);
-      padding: 30px 12px 19px 33px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      z-index: 2;
 
       .okp4-dataverse-portal-modal-content {
         color: themed('text');
-        padding-right: 14px;
+        padding: 14px;
       }
     }
   }

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -9,21 +9,42 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5); // Semi-transparent black overlay
+    background-color: rgba(0, 0, 0, 0.6000000238418579);
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 9999;
 
-    .okp4-dataverse-portal-modal-content {
+    .okp4-dataverse-portal-modal-dialog {
       background: themed('modal-background');
-      overflow-y: auto;
       border-radius: 12px;
-      box-shadow: 4px 4px 8px 0px rgba(0, 0, 0, 0.06); //?
-      padding: 19px 33px;
-      width: 292px;
-      max-height: 655px;
-      color: themed('text');
-      @include columns-with-gap(30px);
+      box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.06);
+      padding: 30px 12px 19px 33px;
+      width: 313px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      z-index: 2;
+
+      @include use-breakpoints(('mobile', 'tablet')) {
+        width: 307px;
+      }
+
+      .okp4-dataverse-portal-modal-wrapper {
+        max-height: 605px;
+        overflow-y: auto;
+
+        .okp4-dataverse-portal-modal-content {
+          color: themed('text');
+          @include columns-with-gap(30px);
+          padding-right: 14px;
+        }
+      }
+
+      .okp4-dataverse-portal-modal-button {
+        margin-top: 40px;
+        width: 120px;
+      }
     }
   }
 }

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -1,0 +1,29 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-modal-main {
+  @include with-theme {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); // Semi-transparent black overlay
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .okp4-dataverse-portal-modal-content {
+      background: themed('modal-background');
+      overflow-y: auto;
+      border-radius: 12px;
+      box-shadow: 4px 4px 8px 0px rgba(0, 0, 0, 0.06); //?
+      padding: 19px 33px;
+      width: 292px;
+      max-height: 655px;
+      color: themed('text');
+      @include columns-with-gap(30px);
+    }
+  }
+}

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -10,10 +10,13 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.6000000238418579);
-    display: flex;
-    justify-content: center;
-    align-items: center;
     z-index: 999;
+
+    &.centered {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
 
     .okp4-dataverse-portal-modal-dialog {
       background: themed('modal-background');

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -1,5 +1,3 @@
-@import '@/ui/style/fonts.scss';
-@import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins.scss';
 
 .okp4-dataverse-portal-modal-main {

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -13,7 +13,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 9999;
+    z-index: 999;
 
     .okp4-dataverse-portal-modal-dialog {
       background: themed('modal-background');
@@ -24,51 +24,32 @@
       flex-direction: column;
       align-items: center;
       z-index: 2;
-      opacity: 1;
-      transform: scale(1);
-      transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
 
       .okp4-dataverse-portal-modal-content {
-        @include columns-with-gap(30px);
         color: themed('text');
         padding-right: 14px;
-      }
-
-      &.zoom {
-        &.open {
-          animation: zoomIn 2s ease-in-out;
-        }
-      }
-
-      &.zoom {
-        &:not(.open) {
-          animation: zoomOut 2s ease-in-out;
-        }
       }
     }
   }
 }
 
-@keyframes zoomIn {
-  0% {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
+.zoom-transition-enter .okp4-dataverse-portal-modal-dialog {
+  opacity: 0;
+  transform: scale(0.9);
 }
 
-@keyframes zoomOut {
-  0% {
-    opacity: 1;
-    transform: scale(1);
-  }
+.zoom-transition-enter-active .okp4-dataverse-portal-modal-dialog {
+  opacity: 1;
+  transform: translateX(0);
+  transition: all 0.2s;
+}
 
-  100% {
-    opacity: 0;
-    transform: scale(0.8);
-  }
+.zoom-transition-exit .okp4-dataverse-portal-modal-dialog {
+  opacity: 1;
+}
+
+.zoom-transition-exit-active .okp4-dataverse-portal-modal-dialog {
+  opacity: 0;
+  transform: scale(0.9);
+  transition: all 0.2s;
 }

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -1,0 +1,61 @@
+import { type ReactNode, type FC, useCallback } from 'react'
+import classNames from 'classnames'
+import { Button } from '@/ui/component/button/button'
+import './modal.scss'
+
+type ModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  closeOnEsc?: boolean
+  isCentered?: boolean
+  motionPreset?: string
+  children?: ReactNode
+  classes?: {
+    main?: string
+    overlay?: string
+  }
+}
+
+export const Modal: FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  closeOnEsc = true,
+  isCentered = false,
+  motionPreset,
+  children,
+  classes
+}) => {
+  const handleKeyPress = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (closeOnEsc && event.key === 'Escape') {
+        onClose()
+      }
+    },
+    [closeOnEsc, onClose]
+  )
+
+  const handleOverlayClick = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  return isOpen ? (
+    <div
+      className={classNames('okp4-dataverse-portal-modal-main', classes?.overlay)}
+      onClick={handleOverlayClick}
+    >
+      <div
+        className={classNames(
+          'okp4-dataverse-portal-modal-content',
+          classes?.main,
+          isCentered,
+          motionPreset
+        )}
+        onKeyDown={handleKeyPress}
+        role="dialog" //?
+      >
+        {children}
+        <Button label="Close" onClick={onClose} variant="outlined-tertiary" />
+      </div>
+    </div>
+  ) : null
+}

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -31,7 +31,7 @@ export const Modal: FC<ModalProps> = ({
   const containerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    containerRef.current = document.querySelector('.okp4-dataverse-portal-main-layout')
+    containerRef.current = document.getElementById('modal-root')
   }, [])
 
   const handleEscape = useCallback(

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -9,6 +9,8 @@ type ModalProps = {
   isOpen: boolean
   onClose: () => void
   closeOnEsc?: boolean
+  motionPreset?: 'zoom' | 'none'
+  isCentered?: boolean
   children?: ReactNode
   classes?: {
     main?: string
@@ -21,6 +23,8 @@ export const Modal: FC<ModalProps> = ({
   isOpen,
   onClose,
   closeOnEsc = true,
+  motionPreset = 'zoom',
+  isCentered = true,
   children,
   classes
 }) => {
@@ -45,20 +49,25 @@ export const Modal: FC<ModalProps> = ({
     containerElement &&
     createPortal(
       <CSSTransition
-        // classNames={motionPreset === 'zoom' ? 'zoom-transition' : ''}
-        className="zoom-transition"
+        classNames={motionPreset === 'zoom' ? 'zoom-transition' : ''}
         in={isOpen}
         timeout={200}
         unmountOnExit
       >
-        onClick={handleOverlayClick}
-      >
         <div
-          className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
-          role="dialog"
+          className={classNames(
+            'okp4-dataverse-portal-modal-main',
+            isCentered && 'centered',
+            classes?.overlay
+          )}
+          onClick={handleOverlayClick}
         >
-          <div className="okp4-dataverse-portal-modal-content">{children}</div>
-        </div>
+          <div
+            className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
+            role="dialog"
+          >
+            <div className="okp4-dataverse-portal-modal-content">{children}</div>
+          </div>
         </div>
       </CSSTransition>,
       containerElement

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type FC, useCallback } from 'react'
+import { type ReactNode, type FC, useCallback, useEffect } from 'react'
 import classNames from 'classnames'
 import { Button } from '@/ui/component/button/button'
 import './modal.scss'
@@ -16,17 +16,18 @@ type ModalProps = {
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 export const Modal: FC<ModalProps> = ({
   isOpen,
   onClose,
   closeOnEsc = true,
-  isCentered = false,
+  isCentered = true,
   motionPreset,
   children,
   classes
 }) => {
   const handleKeyPress = useCallback(
-    (event: React.KeyboardEvent) => {
+    (event: { key: string }) => {
       if (closeOnEsc && event.key === 'Escape') {
         onClose()
       }
@@ -38,24 +39,49 @@ export const Modal: FC<ModalProps> = ({
     onClose()
   }, [onClose])
 
-  return isOpen ? (
-    <div
-      className={classNames('okp4-dataverse-portal-modal-main', classes?.overlay)}
-      onClick={handleOverlayClick}
-    >
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      handleKeyPress(event)
+    }
+
+    if (isOpen && closeOnEsc) {
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      if (closeOnEsc) {
+        document.removeEventListener('keydown', handleKeyDown)
+      }
+    }
+  }, [closeOnEsc, handleKeyPress, isOpen])
+
+  return (
+    isOpen && (
       <div
-        className={classNames(
-          'okp4-dataverse-portal-modal-content',
-          classes?.main,
-          isCentered,
-          motionPreset
-        )}
-        onKeyDown={handleKeyPress}
-        role="dialog" //?
+        className={classNames('okp4-dataverse-portal-modal-main', classes?.overlay)}
+        onClick={handleOverlayClick}
       >
-        {children}
-        <Button label="Close" onClick={onClose} variant="outlined-tertiary" />
+        <div
+          className={classNames(
+            'okp4-dataverse-portal-modal-dialog',
+            classes?.main,
+            isCentered,
+            motionPreset
+          )}
+          onKeyDown={handleKeyPress}
+          role="dialog" //?
+        >
+          <div className="okp4-dataverse-portal-modal-wrapper">
+            <div className="okp4-dataverse-portal-modal-content">{children}</div>
+          </div>
+          <Button
+            className="okp4-dataverse-portal-modal-button"
+            label="Close"
+            onClick={onClose}
+            variant="outlined-secondary"
+          />
+        </div>
       </div>
-    </div>
-  ) : null
+    )
+  )
 }

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type FC, useCallback } from 'react'
+import { type ReactNode, type FC, useCallback, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import classNames from 'classnames'
 import { CSSTransition } from 'react-transition-group'
@@ -28,6 +28,12 @@ export const Modal: FC<ModalProps> = ({
   children,
   classes
 }) => {
+  const containerRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    containerRef.current = document.querySelector('.okp4-dataverse-portal-main-layout')
+  }, [])
+
   const handleEscape = useCallback(
     (event: KeyboardEvent) => {
       if (closeOnEsc && event.key === 'Escape') {
@@ -43,34 +49,42 @@ export const Modal: FC<ModalProps> = ({
     onClose()
   }, [onClose])
 
-  const containerElement = document.getElementById('modal')
+  const handleDialogOnClick = useCallback((e: React.MouseEvent): void => {
+    e.stopPropagation()
+  }, [])
 
-  return (
-    containerElement &&
-    createPortal(
-      <CSSTransition
-        classNames={motionPreset === 'zoom' ? 'zoom-transition' : ''}
-        in={isOpen}
-        timeout={200}
-        unmountOnExit
+  if (!containerRef.current) {
+    return null
+  }
+
+  return createPortal(
+    <CSSTransition
+      classNames={motionPreset === 'zoom' ? 'zoom-transition' : ''}
+      in={isOpen}
+      nodeRef={containerRef}
+      timeout={200}
+      unmountOnExit
+    >
+      <div
+        className={classNames(
+          'okp4-dataverse-portal-modal-main',
+          isCentered && 'centered',
+          classes?.overlay
+        )}
+        onClick={handleOverlayClick}
       >
         <div
-          className={classNames(
-            'okp4-dataverse-portal-modal-main',
-            isCentered && 'centered',
-            classes?.overlay
-          )}
-          onClick={handleOverlayClick}
+          aria-hidden
+          aria-modal
+          className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
+          onClick={handleDialogOnClick}
+          role="dialog"
+          tabIndex={-1}
         >
-          <div
-            className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
-            role="dialog"
-          >
-            <div className="okp4-dataverse-portal-modal-content">{children}</div>
-          </div>
+          <div className="okp4-dataverse-portal-modal-content">{children}</div>
         </div>
-      </CSSTransition>,
-      containerElement
-    )
+      </div>
+    </CSSTransition>,
+    containerRef.current
   )
 }

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode, type FC, useCallback, useRef, useState, useEffect } from 'react'
+import { type ReactNode, type FC, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import classNames from 'classnames'
+import { CSSTransition } from 'react-transition-group'
 import { useOnKeyboard } from '@/ui/hook/useOnKeyboard'
 import './modal.scss'
 
@@ -8,8 +9,6 @@ type ModalProps = {
   isOpen: boolean
   onClose: () => void
   closeOnEsc?: boolean
-  isCentered?: boolean
-  motionPreset?: 'zoom' | 'none'
   children?: ReactNode
   classes?: {
     main?: string
@@ -22,8 +21,6 @@ export const Modal: FC<ModalProps> = ({
   isOpen,
   onClose,
   closeOnEsc = true,
-  isCentered = true,
-  motionPreset = 'zoom',
   children,
   classes
 }) => {
@@ -44,40 +41,26 @@ export const Modal: FC<ModalProps> = ({
 
   const containerElement = document.getElementById('modal')
 
-  const prevIsOpenRef = useRef(isOpen)
-
-  const [isClosing, setIsClosing] = useState(false)
-
-  useEffect(() => {
-    if (prevIsOpenRef.current && !isOpen) {
-      setIsClosing(true)
-      const timeoutId = setTimeout(() => {
-        setIsClosing(false)
-      }, 200)
-      return () => clearTimeout(timeoutId)
-    }
-    prevIsOpenRef.current = isOpen
-  }, [isOpen])
-
   return (
-    isOpen &&
     containerElement &&
     createPortal(
-      <div
-        className={classNames('okp4-dataverse-portal-modal-main', classes?.overlay)}
+      <CSSTransition
+        // classNames={motionPreset === 'zoom' ? 'zoom-transition' : ''}
+        className="zoom-transition"
+        in={isOpen}
+        timeout={200}
+        unmountOnExit
+      >
         onClick={handleOverlayClick}
       >
         <div
-          className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main, isCentered, {
-            zoom: motionPreset === 'zoom',
-            open: isOpen,
-            closing: isClosing
-          })}
+          className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
           role="dialog"
         >
           <div className="okp4-dataverse-portal-modal-content">{children}</div>
         </div>
-      </div>,
+        </div>
+      </CSSTransition>,
       containerElement
     )
   )

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -49,7 +49,7 @@ export const Modal: FC<ModalProps> = ({
     onClose()
   }, [onClose])
 
-  const handleDialogOnClick = useCallback((e: React.MouseEvent): void => {
+  const preventPropagation = useCallback((e: React.MouseEvent): void => {
     e.stopPropagation()
   }, [])
 
@@ -77,7 +77,7 @@ export const Modal: FC<ModalProps> = ({
           aria-hidden
           aria-modal
           className={classNames('okp4-dataverse-portal-modal-dialog', classes?.main)}
-          onClick={handleDialogOnClick}
+          onClick={preventPropagation}
           role="dialog"
           tabIndex={-1}
         >

--- a/src/ui/style/palette.scss
+++ b/src/ui/style/palette.scss
@@ -159,3 +159,7 @@ $dropdown-tags-color: $primary;
 $dropdown-tags-background: rgba(0, 103, 150, 0.12);
 $dropdown-content-background-light: #ffffff;
 $dropdown-content-background-dark: $dropdown-background-dark;
+
+// modal
+$modal-background-dark: linear-gradient(360deg, #242433 0%, #2f2f42 100%);
+$modal-background-light: linear-gradient(360deg, #f2f6f9 0%, #fff 100%);

--- a/src/ui/style/palette.scss
+++ b/src/ui/style/palette.scss
@@ -162,4 +162,4 @@ $dropdown-content-background-dark: $dropdown-background-dark;
 
 // modal
 $modal-background-dark: linear-gradient(360deg, #242433 0%, #2f2f42 100%);
-$modal-background-light: linear-gradient(360deg, #f2f6f9 0%, #fff 100%);
+$modal-background-light: linear-gradient(360deg, #f2f6f9 0%, #ffffff 100%);

--- a/src/ui/style/theme.scss
+++ b/src/ui/style/theme.scss
@@ -81,7 +81,8 @@ $themes: (
     dropdown-border: $dropdown-border-light,
     dropdown-tags-color: $dropdown-tags-color,
     dropdown-tags-background: $dropdown-tags-background,
-    dropdown-content-background: $dropdown-content-background-light
+    dropdown-content-background: $dropdown-content-background-light,
+    modal-background: $modal-background-light
   ),
   dark: (
     primary-color: $primary,
@@ -162,7 +163,8 @@ $themes: (
     dropdown-border: $dropdown-background-dark,
     dropdown-tags-color: $dropdown-tags-color,
     dropdown-tags-background: $dropdown-tags-background,
-    dropdown-content-background: $dropdown-content-background-dark
+    dropdown-content-background: $dropdown-content-background-dark,
+    modal-background: $modal-background-dark
   )
 );
 


### PR DESCRIPTION
This PR adds a generic modal component. Linked issue #422 

## Testing

Easiest place to test the modal component could be in the `notFoundError` page. Here is a code snippet to test:

 ``` jsx 
 const [isModalOpen, setModalOpen] = useState(false)

  const handleOpenModal = useCallback(() => {
    setModalOpen(true)
  }, [])

  const handleCloseModal = useCallback(() => {
    setModalOpen(false)
  }, [])  

```
  
and in return statement:

 ``` jsx
<div id="modal">
    <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
        <h2>Hello, I am inside the modal!</h2>
        <p>
          This is the body of the modal!
        </p>
    </Modal>
 </div>  
```
 also don't forget to change the function in one of the page buttons:

 ```jsx

  <Button
      className="okp4-dataverse-portal-error-page-button"
      label={t('returnToHome')}
      onClick={handleOpenModal}
   />
```

## Screenshots

<details>

<summary> Modal </summary> 

<img width="1130" alt="image" src="https://github.com/okp4/dataverse-portal/assets/83208740/7ea84689-9f38-4bbb-8e72-873ad822a639">


</details>


## Notes

This is just a generic component. Additional styles will be handled in the okp4-modal component. Content style will be handled separately either in the okp4-modal component or directly in the app where the component is used.