### PR TITLE
feat: add okp4 modal

### DIFF
--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -1,4 +1,4 @@
-@import '@/ui/style/mixins.scss';
+@import '@/ui/style/theme.scss';
 
 .okp4-dataverse-portal-modal-main {
   @include with-theme {
@@ -23,7 +23,7 @@
 
       .okp4-dataverse-portal-modal-content {
         color: themed('text');
-        padding: 14px;
+        padding: 12px;
       }
     }
   }

--- a/src/ui/component/modal/modal.scss
+++ b/src/ui/component/modal/modal.scss
@@ -20,11 +20,6 @@
       background: themed('modal-background');
       border-radius: 12px;
       box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.06);
-
-      .okp4-dataverse-portal-modal-content {
-        color: themed('text');
-        padding: 12px;
-      }
     }
   }
 }

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -81,7 +81,7 @@ export const Modal: FC<ModalProps> = ({
           role="dialog"
           tabIndex={-1}
         >
-          <div className="okp4-dataverse-portal-modal-content">{children}</div>
+          {children}
         </div>
       </div>
     </CSSTransition>,

--- a/src/ui/component/modal/modal.tsx
+++ b/src/ui/component/modal/modal.tsx
@@ -5,7 +5,7 @@ import { CSSTransition } from 'react-transition-group'
 import { useOnKeyboard } from '@/ui/hook/useOnKeyboard'
 import './modal.scss'
 
-type ModalProps = {
+export type ModalProps = {
   isOpen: boolean
   onClose: () => void
   closeOnEsc?: boolean

--- a/src/ui/style/palette.scss
+++ b/src/ui/style/palette.scss
@@ -163,3 +163,5 @@ $dropdown-content-background-dark: $dropdown-background-dark;
 // modal
 $modal-background-dark: linear-gradient(360deg, #242433 0%, #2f2f42 100%);
 $modal-background-light: linear-gradient(360deg, #f2f6f9 0%, #ffffff 100%);
+$modal-line-divider-light: rgba(0, 64, 115, 0.12);
+$modal-line-divider-dark: rgba(255, 255, 255, 0.12);

--- a/src/ui/style/theme.scss
+++ b/src/ui/style/theme.scss
@@ -82,7 +82,8 @@ $themes: (
     dropdown-tags-color: $dropdown-tags-color,
     dropdown-tags-background: $dropdown-tags-background,
     dropdown-content-background: $dropdown-content-background-light,
-    modal-background: $modal-background-light
+    modal-background: $modal-background-light,
+    modal-line-divider: $modal-line-divider-light
   ),
   dark: (
     primary-color: $primary,
@@ -164,7 +165,8 @@ $themes: (
     dropdown-tags-color: $dropdown-tags-color,
     dropdown-tags-background: $dropdown-tags-background,
     dropdown-content-background: $dropdown-content-background-dark,
-    modal-background: $modal-background-dark
+    modal-background: $modal-background-dark,
+    modal-line-divider: $modal-line-divider-dark
   )
 );
 

--- a/src/ui/view/modal/okp4-modal.scss
+++ b/src/ui/view/modal/okp4-modal.scss
@@ -3,39 +3,35 @@
 
 .okp4-dataverse-portal-okp4-modal-main {
   @include with-theme {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: themed('text');
+    padding: 12px;
     width: 358px;
+
     @include use-breakpoints(('mobile', 'tablet')) {
       width: 352px;
     }
 
-    .okp4-dataverse-portal-modal-content {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
+    .okp4-dataverse-portal-okp4-modal-top-element {
+      max-height: 78px;
+    }
 
-      .okp4-dataverse-portal-okp4-modal-top-element {
-        max-height: 75px;
-        display: flex;
-        align-items: center;
-      }
+    .okp4-dataverse-portal-okp4-modal-top-element-divider {
+      border-top: 1px solid themed('modal-line-divider');
+      width: 358px;
+    }
 
-      .okp4-dataverse-portal-okp4-modal-top-element-divider {
-        border-top: 1px solid themed('modal-line-divider');
-        width: 358px;
-      }
+    .okp4-dataverse-portal-okp4-modal-content {
+      max-height: 455px;
+      overflow-y: auto;
+      padding: 0 14px 0 21px;
+      margin-top: 20px;
+    }
 
-      .okp4-dataverse-portal-okp4-modal-content {
-        height: 455px;
-        overflow-y: auto;
-        padding: 0 14px 0 21px;
-        margin-top: 20px;
-      }
-
-      .okp4-dataverse-portal-okp4-modal-bottom-element {
-        height: 75px;
-        display: flex;
-        align-items: center;
-      }
+    .okp4-dataverse-portal-okp4-modal-bottom-element {
+      max-height: 78px;
     }
   }
 }

--- a/src/ui/view/modal/okp4-modal.scss
+++ b/src/ui/view/modal/okp4-modal.scss
@@ -7,7 +7,6 @@
     flex-direction: column;
     align-items: center;
     color: themed('text');
-    padding: 12px;
     width: 358px;
 
     @include use-breakpoints(('mobile', 'tablet')) {
@@ -15,23 +14,28 @@
     }
 
     .okp4-dataverse-portal-okp4-modal-top-element {
-      max-height: 78px;
+      height: 66px;
+      padding: 12px 12px 0;
     }
 
     .okp4-dataverse-portal-okp4-modal-top-element-divider {
       border-top: 1px solid themed('modal-line-divider');
-      width: 358px;
+      width: 100%;
     }
 
-    .okp4-dataverse-portal-okp4-modal-content {
-      max-height: 455px;
-      overflow-y: auto;
-      padding: 0 14px 0 21px;
-      margin-top: 20px;
+    .okp4-dataverse-portal-okp4-modal-content-container {
+      padding: 12px;
+
+      .okp4-dataverse-portal-okp4-modal-content {
+        max-height: 458px;
+        overflow-y: auto;
+        padding: 0 14px 0 21px;
+        margin: 8px 0;
+      }
     }
 
     .okp4-dataverse-portal-okp4-modal-bottom-element {
-      max-height: 78px;
+      height: 78px;
     }
   }
 }

--- a/src/ui/view/modal/okp4-modal.scss
+++ b/src/ui/view/modal/okp4-modal.scss
@@ -1,0 +1,41 @@
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-okp4-modal-main {
+  @include with-theme {
+    width: 358px;
+    @include use-breakpoints(('mobile', 'tablet')) {
+      width: 352px;
+    }
+
+    .okp4-dataverse-portal-modal-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      .okp4-dataverse-portal-okp4-modal-top-element {
+        max-height: 75px;
+        display: flex;
+        align-items: center;
+      }
+
+      .okp4-dataverse-portal-okp4-modal-top-element-divider {
+        border-top: 1px solid themed('modal-line-divider');
+        width: 358px;
+      }
+
+      .okp4-dataverse-portal-okp4-modal-content {
+        height: 455px;
+        overflow-y: auto;
+        padding: 0 14px 0 21px;
+        margin-top: 20px;
+      }
+
+      .okp4-dataverse-portal-okp4-modal-bottom-element {
+        height: 75px;
+        display: flex;
+        align-items: center;
+      }
+    }
+  }
+}

--- a/src/ui/view/modal/okp4-modal.scss
+++ b/src/ui/view/modal/okp4-modal.scss
@@ -14,7 +14,7 @@
     }
 
     .okp4-dataverse-portal-okp4-modal-top-element {
-      height: 66px;
+      min-height: 66px;
       padding: 12px 12px 0;
     }
 
@@ -35,7 +35,8 @@
     }
 
     .okp4-dataverse-portal-okp4-modal-bottom-element {
-      height: 78px;
+      min-height: 66px;
+      padding: 0 12px 12px;
     }
   }
 }

--- a/src/ui/view/modal/okp4-modal.tsx
+++ b/src/ui/view/modal/okp4-modal.tsx
@@ -1,0 +1,19 @@
+import { type FC } from 'react'
+import { Modal, type ModalProps } from '@/ui/component/modal/modal'
+import './okp4-modal.scss'
+
+type Okp4ModalProps = ModalProps & {
+  topElement: JSX.Element
+  bottomElement: JSX.Element
+}
+
+export const Okp4Modal: FC<Okp4ModalProps> = ({ topElement, bottomElement, ...modalProps }) => {
+  return (
+    <Modal {...modalProps} classes={{ main: 'okp4-dataverse-portal-okp4-modal-main' }}>
+      <div className="okp4-dataverse-portal-okp4-modal-top-element">{topElement} </div>
+      <div className="okp4-dataverse-portal-okp4-modal-top-element-divider" />
+      <div className="okp4-dataverse-portal-okp4-modal-content">{modalProps.children}</div>
+      <div className="okp4-dataverse-portal-okp4-modal-bottom-element">{bottomElement} </div>
+    </Modal>
+  )
+}

--- a/src/ui/view/modal/okp4-modal.tsx
+++ b/src/ui/view/modal/okp4-modal.tsx
@@ -7,13 +7,13 @@ type Okp4ModalProps = ModalProps & {
   bottomElement: JSX.Element
 }
 
-export const Okp4Modal: FC<Okp4ModalProps> = ({ topElement, bottomElement, ...modalProps }) => {
-  return (
-    <Modal {...modalProps} classes={{ main: 'okp4-dataverse-portal-okp4-modal-main' }}>
-      <div className="okp4-dataverse-portal-okp4-modal-top-element">{topElement} </div>
-      <div className="okp4-dataverse-portal-okp4-modal-top-element-divider" />
+export const Okp4Modal: FC<Okp4ModalProps> = ({ topElement, bottomElement, ...modalProps }) => (
+  <Modal {...modalProps} classes={{ main: 'okp4-dataverse-portal-okp4-modal-main' }}>
+    <div className="okp4-dataverse-portal-okp4-modal-top-element">{topElement} </div>
+    <div className="okp4-dataverse-portal-okp4-modal-top-element-divider" />
+    <div className="okp4-dataverse-portal-okp4-modal-content-container">
       <div className="okp4-dataverse-portal-okp4-modal-content">{modalProps.children}</div>
-      <div className="okp4-dataverse-portal-okp4-modal-bottom-element">{bottomElement} </div>
-    </Modal>
-  )
-}
+    </div>
+    <div className="okp4-dataverse-portal-okp4-modal-bottom-element">{bottomElement} </div>
+  </Modal>
+)


### PR DESCRIPTION
This PR adds OKP4 modal.

In addition to the modal component, this PR adds a more customized OKP4 modal component with added top and bottom section and additional appropriate styles.

## Testing

Easiest place to test the OKP4 modal component could be in the `notFoundError` page. Here is a code snippet to test:

 ``` jsx 
 const [isModalOpen, setModalOpen] = useState(false)

  const handleOpenModal = useCallback(() => {
    setModalOpen(true)
  }, [])

  const handleCloseModal = useCallback(() => {
    setModalOpen(false)
  }, [])  

```
  
and in return statement:

 ``` jsx
  <Okp4Modal
          bottomElement={<h1>This is a custom footer</h1>}
          closeOnEsc
          isCentered
          isOpen={isModalOpen}
          onClose={handleCloseModal}
          topElement={<h1>This is a custom header</h1>}
   >
    <p>
      This is the body of the modal!
    </p>
  </Okp4Modal>
```
 also don't forget to change the function in one of the page buttons:

 ```jsx

  <Button
      className="okp4-dataverse-portal-error-page-button"
      label={t('returnToHome')}
      onClick={handleOpenModal}
   />
``` 

## Screenshots

<details>

<summary> OKP4 modal light</summary> 

<img width="988" alt="image" src="https://github.com/okp4/dataverse-portal/assets/83208740/47411b11-12a2-48a5-8678-5cac0ac0596f">

</details>

<details>

<summary> OKP4 modal dark</summary> 

<img width="983" alt="image" src="https://github.com/okp4/dataverse-portal/assets/83208740/84544a36-ca16-4b8b-beb5-70f6bbe8341c">

</details>

## Notes

Additional content styles should be handled by the parent.