### PR TITLE
feat(metadataFilling): make know field typed as text

### DIFF
--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
@@ -114,14 +114,6 @@ export const MetadataFilling: FC = () => {
     [setFormItemValue]
   )
 
-  const handleNumericValueChange = useCallback(
-    (id: string) => (event: ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value
-      !isNaN(Number(value)) && setFormItemValue(id, Number(value))()
-    },
-    [setFormItemValue]
-  )
-
   const numericalFieldValue = (v: DatasetFormItem['value']) => (): string =>
     pipe(
       v,
@@ -357,7 +349,7 @@ export const MetadataFilling: FC = () => {
       },
       {
         id: id10,
-        type: 'numeric',
+        type: 'text',
         title: 'fee',
         value: O.none,
         render: (): JSX.Element => (
@@ -368,7 +360,7 @@ export const MetadataFilling: FC = () => {
               id={id10}
               max={Infinity}
               min={0}
-              onChange={handleNumericValueChange(id10)}
+              onChange={handleFieldValueChange(id10)}
               placeholder="0"
               precision={APP_ENV.chains[0].feeCurrencies[0].coinDecimals}
               rightElement={<span>{APP_ENV.chains[0].currencies[0].coinDenom}</span>}
@@ -382,14 +374,7 @@ export const MetadataFilling: FC = () => {
         }
       }
     ]
-  }, [
-    t,
-    handleFieldValueChange,
-    singleValueField,
-    multiValuesField,
-    handleNumericValueChange,
-    handleTagsFieldValueChange
-  ])
+  }, [t, handleFieldValueChange, singleValueField, multiValuesField, handleTagsFieldValueChange])
 
   const mapForm = (form: DatasetForm): InitFormPayload =>
     form.map(formItem => {

--- a/src/ui/store/slice/shareData/test/shareDataSlice.spec.ts
+++ b/src/ui/store/slice/shareData/test/shareDataSlice.spec.ts
@@ -122,6 +122,14 @@ describe('Given the share data slice', () => {
     value: O.some(['Agriculture', 'Open Data', 'Dataviz'])
   }
 
+  const textItemFeesID6: FormItem = {
+    id: '6',
+    title: 'fees',
+    required: false,
+    type: 'text',
+    value: O.some('1 082 689.998')
+  }
+
   // init form payloads
   const initialFormPayload1: InitFormPayload = [textItemID2]
 
@@ -189,6 +197,11 @@ describe('Given the share data slice', () => {
   const numericFormItemPayloadID5: SetFormItemValuePayload = {
     id: '5',
     value: 6
+  }
+
+  const textFormItemFeesPayloadID6: SetFormItemValuePayload = {
+    id: '6',
+    value: '1 632.02547'
   }
 
   // preloaded states
@@ -284,6 +297,11 @@ describe('Given the share data slice', () => {
   const expectedTagsWithoutRemovedTagFormItem5: FormItem = {
     ...tagItemID5,
     value: O.some(['Agriculture', 'Dataviz'])
+  }
+
+  const expectedTextFormItemFeesID6: FormItem = {
+    ...textItemFeesID6,
+    value: O.some('1 632.02547')
   }
 
   describe.each`
@@ -409,6 +427,7 @@ describe('Given the share data slice', () => {
     ${preloadedStateWithFormItem(tagItemID5)}           | ${addTagFormItemPayloadID5}                            | ${[expectedTagsWithAdditionalTagFormItem5]}             | ${O.some(expectedTagsWithAdditionalTagFormItem5)}             | ${undefined}                | ${undefined}                                            | ${undefined}
     ${preloadedStateWithFormItem(tagItemID5)}           | ${removeTagFormItemPayloadID5}                         | ${[expectedTagsWithoutRemovedTagFormItem5]}             | ${O.some(expectedTagsWithoutRemovedTagFormItem5)}             | ${undefined}                | ${undefined}                                            | ${undefined}
     ${preloadedStateWithFormItem(tagItemID5)}           | ${numericFormItemPayloadID5}                           | ${[tagItemID5]}                                         | ${O.some(tagItemID5)}                                         | ${undefined}                | ${undefined}                                            | ${FormItemWrongTypeError(tagItemID5.id, tagItemID5.type)}
+    ${preloadedStateWithFormItem(textItemFeesID6)}      | ${textFormItemFeesPayloadID6}                          | ${[expectedTextFormItemFeesID6]}                        | ${O.some(expectedTextFormItemFeesID6)}                        | ${undefined}                | ${undefined}                                            | ${undefined}
   `(
     'Given a form item payload <$formItemPayload> ',
     ({


### PR DESCRIPTION
This PR changes the know field from numeric type to text type.
Indeed, the `NumericField` component returns a string value.
If we had decided to store this value as a number, we would have had to transform it from string to number.
This would also have required us to convert the number to a string when retrieving the value, so as to be able to inject it back into the numeric field.
To do this, we would have had to add spaces as thousand separators and retain the ` . ` as a decimal separator, which would have meant re-encoding the logic of the `NumericField`.
Since numeric inputs retain the field value as a string, I felt it necessary to go in this direction and change `formItem` fee's type to `text`.
This allows us to keep the string as formatted, and we can always transform it into a number if required.
The numeric type has been retained in the slice, even if it's useless for the time being.