### PR TITLE
Feat/use dedicated value type for numeric and text fields

### DIFF
--- a/src/ui/component/field/baseField.tsx
+++ b/src/ui/component/field/baseField.tsx
@@ -4,10 +4,10 @@ import classNames from 'classnames'
 import { Icon } from '@/ui/component/icon/icon'
 import './field.scss'
 
-export type BaseFieldProps = {
+export type BaseFieldProps<T> = {
   id: string
   inputElement: ReactNode
-  value?: string
+  value?: T
   label?: string
   placeholder?: string
   disabled?: boolean
@@ -20,7 +20,7 @@ export type BaseFieldProps = {
 }
 
 // eslint-disable-next-line max-lines-per-function
-export const BaseField: FC<BaseFieldProps> = ({
+export const BaseField: FC<BaseFieldProps<string | number>> = ({
   label,
   error,
   leftElement,

--- a/src/ui/component/field/numericField.tsx
+++ b/src/ui/component/field/numericField.tsx
@@ -9,7 +9,7 @@ import {
   localizedNumberParser,
   thousandSeparatorForLocale
 } from '@/util/i18n/i18n'
-import { without } from '@/util/util'
+import { createIntermediateNumericPattern, without } from '@/util/util'
 import type { BaseFieldProps } from './baseField'
 import { BaseField } from './baseField'
 import './field.scss'
@@ -89,10 +89,7 @@ export const NumericField: FC<NumericFieldProps> = props => {
   const inputRef = useMaskito({ options: numericOptions })
 
   const allowedIntermediatePatterns = useMemo(
-    () =>
-      [decimalSeparator, ...decimalPseudoSeparators].map(
-        separator => new RegExp(`\\${separator}0*$`) // TODO: fix numbers ending with unhandled pattern, like 1.020
-      ),
+    () => [decimalSeparator, ...decimalPseudoSeparators].map(createIntermediateNumericPattern),
     [decimalSeparator, decimalPseudoSeparators]
   )
 

--- a/src/ui/component/field/numericField.tsx
+++ b/src/ui/component/field/numericField.tsx
@@ -9,7 +9,7 @@ import { BaseField } from './baseField'
 import './field.scss'
 import { without } from '@/util/util'
 
-type NumericFieldProps = Omit<BaseFieldProps, 'inputElement'> & {
+type NumericFieldProps = Omit<BaseFieldProps<number>, 'inputElement'> & {
   precision?: number
   thousandSeparator?: string
   decimalSeparator?: string

--- a/src/ui/component/field/numericField.tsx
+++ b/src/ui/component/field/numericField.tsx
@@ -3,11 +3,16 @@ import { useCallback, useMemo } from 'react'
 import { maskitoNumberOptionsGenerator } from '@maskito/kit'
 import { useMaskito } from '@maskito/react'
 import { useTranslation } from 'react-i18next'
-import { decimalSeparatorForLocale, thousandSeparatorForLocale } from '@/util/i18n/i18n'
+import {
+  decimalSeparatorForLocale,
+  localizedNumberFormatter,
+  localizedNumberParser,
+  thousandSeparatorForLocale
+} from '@/util/i18n/i18n'
+import { without } from '@/util/util'
 import type { BaseFieldProps } from './baseField'
 import { BaseField } from './baseField'
 import './field.scss'
-import { without } from '@/util/util'
 
 type NumericFieldProps = Omit<BaseFieldProps<number>, 'inputElement'> & {
   precision?: number
@@ -21,7 +26,7 @@ type NumericFieldProps = Omit<BaseFieldProps<number>, 'inputElement'> & {
 
 // eslint-disable-next-line max-lines-per-function
 export const NumericField: FC<NumericFieldProps> = props => {
-  const { i18n } = useTranslation()
+  const locale = useTranslation().i18n.language
 
   const {
     label,
@@ -29,8 +34,8 @@ export const NumericField: FC<NumericFieldProps> = props => {
     leftElement,
     rightElement,
     precision,
-    thousandSeparator = thousandSeparatorForLocale(i18n.language),
-    decimalSeparator = decimalSeparatorForLocale(i18n.language),
+    thousandSeparator = thousandSeparatorForLocale(locale),
+    decimalSeparator = decimalSeparatorForLocale(locale),
     decimalPseudoSeparators = without([thousandSeparator])(
       // eslint-disable-next-line react/destructuring-assignment
       props.decimalPseudoSeparators ?? [',', '.', 'ю', 'б']
@@ -41,7 +46,32 @@ export const NumericField: FC<NumericFieldProps> = props => {
     ...inputProps
   } = props
 
-  const { id } = inputProps
+  const { id, value } = inputProps
+
+  const parseLocalizedNumber = useMemo(
+    () => localizedNumberParser(locale, decimalSeparator, thousandSeparator),
+    [locale, decimalSeparator, thousandSeparator]
+  )
+
+  const formatLocalizedNumber = useMemo(
+    () =>
+      localizedNumberFormatter(
+        {
+          useGrouping: true,
+          minimumFractionDigits: 0,
+          maximumFractionDigits: precision
+        },
+        locale,
+        decimalSeparator,
+        thousandSeparator
+      ),
+    [locale, decimalSeparator, thousandSeparator, precision]
+  )
+
+  const formattedValue = useMemo(
+    () => (value === undefined ? '' : formatLocalizedNumber(value)),
+    [value, formatLocalizedNumber]
+  )
 
   const numericOptions = useMemo(
     () =>
@@ -61,18 +91,22 @@ export const NumericField: FC<NumericFieldProps> = props => {
   const allowedIntermediatePatterns = useMemo(
     () =>
       [decimalSeparator, ...decimalPseudoSeparators].map(
-        separator => new RegExp(`\\${separator}0*$`)
+        separator => new RegExp(`\\${separator}0*$`) // TODO: fix numbers ending with unhandled pattern, like 1.020
       ),
     [decimalSeparator, decimalPseudoSeparators]
   )
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>): void => {
-      if (allowedIntermediatePatterns.some(pattern => pattern.test(event.target.value))) return
+      const { value } = event.target
+
+      if (allowedIntermediatePatterns.some(pattern => pattern.test(value))) return
+
+      event.target.value = value ? String(parseLocalizedNumber(value)) : ''
 
       onChange?.(event)
     },
-    [onChange, allowedIntermediatePatterns]
+    [onChange, allowedIntermediatePatterns, parseLocalizedNumber]
   )
 
   return (
@@ -86,11 +120,13 @@ export const NumericField: FC<NumericFieldProps> = props => {
           className="okp4-dataverse-portal-field-input"
           name={id}
           onInput={handleChange}
+          value={formattedValue}
         />
       }
       label={label}
       leftElement={leftElement}
       rightElement={rightElement}
+      value={formattedValue}
     />
   )
 }

--- a/src/ui/component/field/textField.tsx
+++ b/src/ui/component/field/textField.tsx
@@ -5,7 +5,7 @@ import type { BaseFieldProps } from './baseField'
 import { BaseField } from './baseField'
 import './field.scss'
 
-type TextFieldProps = Omit<BaseFieldProps, 'inputElement'> & {
+type TextFieldProps = Omit<BaseFieldProps<string>, 'inputElement'> & {
   multiline?: boolean
   resizable?: boolean
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void

--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
@@ -122,22 +122,28 @@ export const MetadataFilling: FC = () => {
     [setFormItemValue]
   )
 
-  const numericalFieldValue = (v: DatasetFormItem['value']) => (): string =>
-    pipe(
-      v,
-      O.chain(O.fromPredicate(N.isNumber)),
-      O.map(N.Show.show),
-      O.getOrElse(constant(S.empty))
-    )
+  const numericValueField = useCallback(
+    (id: string): number =>
+      pipe(
+        id,
+        formItemById,
+        IOO.map(({ value }) => value),
+        IOO.match(constant(0), v =>
+          pipe(v, O.chain(O.fromPredicate(N.isNumber)), O.getOrElse(constant(0)))
+        ),
+        apply(null)
+      ),
+    [formItemById]
+  )
 
-  const singleValueField = useCallback(
+  const textValueField = useCallback(
     (id: string): string =>
       pipe(
         id,
         formItemById,
         IOO.map(({ value }) => value),
         IOO.match(constant(S.empty), v =>
-          pipe(v, O.chain(O.fromPredicate(S.isString)), O.getOrElse(numericalFieldValue(v)))
+          pipe(v, O.chain(O.fromPredicate(S.isString)), O.getOrElse(constant(S.empty)))
         ),
         apply(null)
       ),
@@ -188,7 +194,7 @@ export const MetadataFilling: FC = () => {
               label={t('share.metadataFilling.datasetTitle')}
               onChange={handleFieldValueChange(id1)}
               required
-              value={singleValueField(id1)}
+              value={textValueField(id1)}
             />
           </div>
         ),
@@ -207,7 +213,7 @@ export const MetadataFilling: FC = () => {
               id={id2}
               label={t('share.metadataFilling.publisher')}
               onChange={handleFieldValueChange(id2)}
-              value={singleValueField(id2)}
+              value={textValueField(id2)}
             />
           </div>
         ),
@@ -227,7 +233,7 @@ export const MetadataFilling: FC = () => {
               id={id3}
               label={t('share.metadataFilling.creator')}
               onChange={handleFieldValueChange(id3)}
-              value={singleValueField(id3)}
+              value={textValueField(id3)}
             />
           </div>
         ),
@@ -248,7 +254,7 @@ export const MetadataFilling: FC = () => {
               label={t('share.metadataFilling.description')}
               multiline
               onChange={handleFieldValueChange(id4)}
-              value={singleValueField(id4)}
+              value={textValueField(id4)}
             />
           </div>
         ),
@@ -268,7 +274,7 @@ export const MetadataFilling: FC = () => {
               id={id5}
               label={t('share.metadataFilling.formatSelection')}
               onChange={handleFieldValueChange(id5)}
-              value={singleValueField(id5)}
+              value={textValueField(id5)}
             />
           </div>
         ),
@@ -288,7 +294,7 @@ export const MetadataFilling: FC = () => {
               id={id6}
               label={t('share.metadataFilling.licenceSelection')}
               onChange={handleFieldValueChange(id6)}
-              value={singleValueField(id6)}
+              value={textValueField(id6)}
             />
           </div>
         ),
@@ -308,7 +314,7 @@ export const MetadataFilling: FC = () => {
               id={id7}
               label={t('share.metadataFilling.topicSelection')}
               onChange={handleFieldValueChange(id7)}
-              value={singleValueField(id7)}
+              value={textValueField(id7)}
             />
           </div>
         ),
@@ -328,7 +334,7 @@ export const MetadataFilling: FC = () => {
               id={id8}
               label={t('share.metadataFilling.geographicalCoverageSelection')}
               onChange={handleFieldValueChange(id8)}
-              value={singleValueField(id8)}
+              value={textValueField(id8)}
             />
           </div>
         ),
@@ -373,7 +379,7 @@ export const MetadataFilling: FC = () => {
               precision={APP_ENV.chains[0].feeCurrencies[0].coinDecimals}
               rightElement={<span>{APP_ENV.chains[0].currencies[0].coinDenom}</span>}
               thousandSeparator=" " // narrow no-break space U+202F
-              value={singleValueField(id10)}
+              value={numericValueField(id10)}
             />
           </div>
         ),
@@ -385,7 +391,8 @@ export const MetadataFilling: FC = () => {
   }, [
     t,
     handleFieldValueChange,
-    singleValueField,
+    textValueField,
+    numericValueField,
     multiValuesField,
     handleNumericValueChange,
     handleTagsFieldValueChange

--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
@@ -116,8 +116,11 @@ export const MetadataFilling: FC = () => {
 
   const handleNumericValueChange = useCallback(
     (id: string) => (event: ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value
-      !isNaN(Number(value)) && setFormItemValue(id, Number(value))()
+      const { value } = event.target
+      const isValueValid = value !== '' || !isNaN(Number(value))
+      // TODO: allow to set back to empty value in the slice
+      // User should be able to set back to empty value
+      setFormItemValue(id, isValueValid ? Number(value) : NaN)()
     },
     [setFormItemValue]
   )
@@ -128,8 +131,8 @@ export const MetadataFilling: FC = () => {
         id,
         formItemById,
         IOO.map(({ value }) => value),
-        IOO.match(constant(0), v =>
-          pipe(v, O.chain(O.fromPredicate(N.isNumber)), O.getOrElse(constant(0)))
+        IOO.match(constant(NaN), v =>
+          pipe(v, O.chain(O.fromPredicate(N.isNumber)), O.getOrElse(constant(NaN)))
         ),
         apply(null)
       ),

--- a/src/util/i18n/i18n.spec.ts
+++ b/src/util/i18n/i18n.spec.ts
@@ -110,4 +110,48 @@ describe('I18n utilities', () => {
       }).toThrow('Decimal and thousand separators must be different')
     })
   })
+
+  describe('localizedNumberFormatter and localizedNumberParser', () => {
+    const locales = ['en-US', 'fr-FR', 'de-DE']
+
+    const testCases: Record<string, { number: number; formatted: string }[]> = {
+      'en-US': [
+        { number: 1234.56, formatted: '1,234.56' },
+        { number: 0.2004, formatted: '0.2004' },
+        { number: 987654.32, formatted: '987,654.32' }
+      ],
+      'fr-FR': [
+        { number: 1234.56, formatted: '1 234,56' },
+        { number: 0, formatted: '0' },
+        { number: 987654.32, formatted: '987 654,32' }
+      ],
+      'de-DE': [
+        { number: 1234.56, formatted: '1.234,56' },
+        { number: 0.00001, formatted: '0,000001' },
+        { number: -422, formatted: '-422' },
+        { number: 987654.32, formatted: '987.654,32' }
+      ]
+    }
+
+    locales.forEach(locale => {
+      const format = localizedNumberFormatter(
+        { minimumFractionDigits: 0, maximumFractionDigits: 6 },
+        locale
+      )
+      const parse = localizedNumberParser(locale)
+      const cases = testCases[locale]
+
+      test(`parse ∘ format = Identity for locale ${locale}`, () => {
+        cases.forEach(({ number }) => {
+          expect(parse(format(number))).toBeCloseTo(number)
+        })
+      })
+
+      test(`format ∘ parse = Identity for locale ${locale}`, () => {
+        cases.forEach(({ formatted }) => {
+          expect(format(parse(formatted))).toBe(formatted)
+        })
+      })
+    })
+  })
 })

--- a/src/util/i18n/i18n.spec.ts
+++ b/src/util/i18n/i18n.spec.ts
@@ -1,4 +1,10 @@
-import { decimalSeparatorForLocale, thousandSeparatorForLocale } from './i18n'
+/* eslint-disable max-lines-per-function */
+import {
+  decimalSeparatorForLocale,
+  localizedNumberFormatter,
+  localizedNumberParser,
+  thousandSeparatorForLocale
+} from './i18n'
 
 describe('I18n utilities', () => {
   describe('thousandSeparatorForLocale', () => {
@@ -14,6 +20,94 @@ describe('I18n utilities', () => {
       expect(decimalSeparatorForLocale('fr-FR')).toEqual(',')
       expect(decimalSeparatorForLocale('en-US')).toEqual('.')
       expect(decimalSeparatorForLocale('de-DE')).toEqual(',')
+    })
+  })
+
+  describe('localizedNumberFormatter', () => {
+    describe.each([
+      [
+        'fr-FR',
+        { minimumFractionDigits: 0, maximumFractionDigits: 2 },
+        '.',
+        ' ',
+        1234.56,
+        '1 234.56'
+      ],
+      [
+        'fr-FR',
+        { minimumFractionDigits: 0, maximumFractionDigits: 2 },
+        '.',
+        undefined,
+        1234.56,
+        '1 234.56'
+      ],
+      [
+        'fr-FR',
+        { minimumFractionDigits: 0, maximumFractionDigits: 2 },
+        undefined,
+        undefined,
+        1234.568,
+        '1 234,57'
+      ],
+      [
+        'en-US',
+        { minimumFractionDigits: 0, maximumFractionDigits: 2 },
+        undefined,
+        undefined,
+        1234.568,
+        '1,234.57'
+      ],
+      [
+        'en-US',
+        { minimumFractionDigits: 0, maximumFractionDigits: 2 },
+        ',',
+        '.',
+        1234.568,
+        '1.234,57'
+      ]
+    ])(
+      'formatLocalizedNumber',
+      (locale, options, decimalSeparator, thousandSeparator, input, expectedOutput) => {
+        it(`formats a number according to the specified locale, options, and separators`, () => {
+          const formatter = localizedNumberFormatter(
+            options,
+            locale,
+            decimalSeparator,
+            thousandSeparator
+          )
+          expect(formatter(input)).toEqual(expectedOutput)
+        })
+      }
+    )
+
+    it('throws an error when decimal and thousand separators are the same', () => {
+      expect(() => {
+        localizedNumberFormatter({}, 'en-US', '.', '.')
+      }).toThrow('Decimal and thousand separators must be different')
+    })
+  })
+
+  describe('localizedNumberParser', () => {
+    describe.each([
+      ['fr-FR', '.', ' ', '1 234.56', 1234.56],
+      ['fr-FR', '.', undefined, '1 234.56', 1234.56],
+      ['fr-FR', undefined, undefined, '1 234,57', 1234.57],
+      ['en-US', undefined, undefined, '1,234.57', 1234.57],
+      ['en-US', ',', '.', '1.234,57', 1234.57]
+    ])(
+      'parseLocalizedNumber',
+      (locale, decimalSeparator, thousandSeparator, input, expectedOutput) => {
+        it(`parses a formatted string according to the specified locale and separators`, () => {
+          const parser = localizedNumberParser(locale, decimalSeparator, thousandSeparator)
+          expect(parser(input)).toEqual(expectedOutput)
+        })
+      }
+    )
+
+    it('throws an error when decimal and thousand separators are the same', () => {
+      expect(() => {
+        localizedNumberParser('en-US', '.', '.')
+      }).toThrow('Decimal and thousand separators must be different')
     })
   })
 })

--- a/src/util/i18n/i18n.ts
+++ b/src/util/i18n/i18n.ts
@@ -1,3 +1,6 @@
+import { pipe } from 'fp-ts/function'
+import { escapeRegExp } from '@/util/util'
+
 /**
  * Determines the character used as the thousand separator for a locale.
  *
@@ -20,3 +23,75 @@ export const thousandSeparatorForLocale = (locale: string): string =>
  */
 export const decimalSeparatorForLocale = (locale: string): string =>
   new Intl.NumberFormat(locale, { useGrouping: false }).format(1.1).replace(/1/g, '')
+
+/**
+ * Returns a function that formats a number according to the specified locale and options.
+ * The returned function replaces the decimal and thousand separator with the specified one.
+ *
+ * @param {Intl.NumberFormatOptions} options - The options to use for number formatting.
+ * @param {string=} locale - The locale to use for number formatting, e.g., 'en-US' or 'fr-FR'.
+ * @param {string=} decimalSeparator - The character used as the decimal separator.
+ * @param {string=} thousandSeparator - The character used as the thousand separator.
+ * @returns {(n: number) => string} - A function that formats a number according to the specified locale, options and decimal separator.
+ */
+export const localizedNumberFormatter = (
+  options: Intl.NumberFormatOptions,
+  locale: string = 'en-US',
+  decimalSeparator?: string,
+  thousandSeparator?: string
+): ((n: number) => string) => {
+  if (decimalSeparator && thousandSeparator && decimalSeparator === thousandSeparator) {
+    throw new Error('Decimal and thousand separators must be different')
+  }
+  const regexSeparator = new RegExp(
+    `[${escapeRegExp(thousandSeparatorForLocale(locale))}${escapeRegExp(
+      decimalSeparatorForLocale(locale)
+    )}]`,
+    'g'
+  )
+  const transformCallback = (match: string): string => {
+    if (match === thousandSeparatorForLocale(locale) && thousandSeparator) return thousandSeparator
+    if (match === decimalSeparatorForLocale(locale) && decimalSeparator) return decimalSeparator
+    return match
+  }
+
+  const transformSeparators = (str: string): string =>
+    str.replace(regexSeparator, transformCallback)
+
+  return (n: number): string => pipe(n, n => n.toLocaleString(locale, options), transformSeparators)
+}
+
+/**
+ * Returns a function that parses a localized number string according to the specified locale and options.
+ * The returned function removes the thousand separator and replaces the decimal separator with a dot.
+ *
+ * @param {string=} locale - The locale to use for number formatting, e.g., 'en-US' or 'fr-FR'.
+ * @param {string=} decimalSeparator - The character used as the decimal separator.
+ * @param {string=} thousandSeparator - The character used as the thousand separator.
+ * @returns {(n: number) => string} - A function that parses a localized number string according to the specified locale, thousand and decimal separator.
+ */
+export const localizedNumberParser = (
+  locale: string = 'en-US',
+  decimalSeparator: string = decimalSeparatorForLocale(locale),
+  thousandSeparator: string = thousandSeparatorForLocale(locale)
+): ((s: string) => number) => {
+  if (decimalSeparator && thousandSeparator && decimalSeparator === thousandSeparator) {
+    throw new Error('Decimal and thousand separators must be different')
+  }
+
+  const regexSeparator = new RegExp(
+    `[${escapeRegExp(thousandSeparator)}${escapeRegExp(decimalSeparator)}]`,
+    'g'
+  )
+
+  const transformCallback = (match: string): string => {
+    if (match === thousandSeparator) return ''
+    if (match === decimalSeparator) return '.'
+    return match
+  }
+
+  const transformSeparators = (str: string): string =>
+    str.replace(regexSeparator, transformCallback)
+
+  return (formattedString: string): number => pipe(formattedString, transformSeparators, parseFloat)
+}

--- a/src/util/splitTextWithTerm/splitTextWithTerm.ts
+++ b/src/util/splitTextWithTerm/splitTextWithTerm.ts
@@ -2,6 +2,7 @@ import { pipe } from 'fp-ts/lib/function'
 import * as S from 'fp-ts/string'
 import * as O from 'fp-ts/Option'
 import * as A from 'fp-ts/Array'
+import { escapeRegExp } from '@/util/util'
 
 const isNonEmpty = (s: string): boolean => !S.isEmpty(s)
 
@@ -9,10 +10,6 @@ const isNonEmpty = (s: string): boolean => !S.isEmpty(s)
 // thus preserving only the character that follows the backslash.
 const replaceInvalidEscapeSequences = (s: string): string =>
   s.replace(/\\(x|u|U|v|b|B|c|C|f|n|r|t|0|1|2|3|4|5|6|7|8|9)/g, '$1')
-
-// Escapes all special characters in a string that have significance in a regular expression,
-// allowing the string to be used safely in a RegExp constructor.
-const escapeRegExp = (s: string): string => s.replace(/[\^$.*+?()|[\]{}\\]/g, '\\$&')
 
 /**
  * Splits a given text string at each occurrence of a specified search term.

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -5,7 +5,8 @@ import {
   isSubstringOf,
   escapeSparqlStr,
   updateItemById,
-  without
+  without,
+  createIntermediateNumericPattern
 } from './util'
 import type { Item } from './util'
 
@@ -191,6 +192,32 @@ describe('Considering the without utility function', () => {
       const myObjectArray = [{ id: 1 }, { id: 2 }, { id: 3 }]
       const filteredObjectArray = without(objectsToRemove)(myObjectArray)
       expect(filteredObjectArray).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+    })
+  })
+})
+
+describe('Considering the createIntermediateNumericPattern utility function', () => {
+  const separator = '.'
+  const pattern = createIntermediateNumericPattern(separator)
+
+  describe.each`
+    input             | match
+    ${'7.'}           | ${true}
+    ${'2.0'}          | ${true}
+    ${'2.0200'}       | ${true}
+    ${'2.0002000020'} | ${true}
+    ${'2.2220'}       | ${true}
+    ${'5.0000005505'} | ${false}
+    ${'2.02'}         | ${false}
+    ${'2.2'}          | ${false}
+    ${'2'}            | ${false}
+    ${'2.0002'}       | ${false}
+    ${'2.0020002'}    | ${false}
+  `(`Given a separator "$separator" and a numeric input string "$input"`, ({ input, match }) => {
+    describe(`When testing the pattern against the string "${input}"`, () => {
+      it(`Then it ${match ? 'matches' : 'not match'} the pattern`, () => {
+        expect(pattern.test(input)).toBe(match)
+      })
     })
   })
 })

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -101,3 +101,7 @@ export const updateItemById = <T extends Item>(id: string, items: T[], updatedIt
  */
 export const without = <T>(itemsToRemove: T[]): ((array: T[]) => T[]) =>
   A.filter<T>((item: T) => !itemsToRemove.includes(item))
+
+// Escapes all special characters in a string that have significance in a regular expression,
+// allowing the string to be used safely in a RegExp constructor.
+export const escapeRegExp = (s: string): string => s.replace(/[\^$.*+?()|[\]{}\\]/g, '\\$&')

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -105,3 +105,6 @@ export const without = <T>(itemsToRemove: T[]): ((array: T[]) => T[]) =>
 // Escapes all special characters in a string that have significance in a regular expression,
 // allowing the string to be used safely in a RegExp constructor.
 export const escapeRegExp = (s: string): string => s.replace(/[\^$.*+?()|[\]{}\\]/g, '\\$&')
+
+export const createIntermediateNumericPattern = (separator: string): RegExp =>
+  new RegExp(`${escapeRegExp(separator)}(\\d*0+){0,1}$`)


### PR DESCRIPTION
Changes are related to #445 comments for numeric fields types.

## Purpose
Having distinct value type for each type of field.

## Implementation
Numeric field takes number type value as input and lift up numeric string value through the onChange callback.
The NumericField component handles internally number formatting and parsing, according to separators and locale.

## Important note
We currently fallback the numeric to `0`, but we probably want to allow the user to set back to empty value in the ShareData slice.

Instead of only updating the store if this is a valid value, we might prefer to update the initial value with `undefined`, or `NaN` if we are restricted to type number.

Then we will be able to validate (or not validate) field according to the value store.