### PR TITLE
Feat/multiselect dropdown

### DIFF
--- a/src/ui/component/dropDown/dropDown.tsx
+++ b/src/ui/component/dropDown/dropDown.tsx
@@ -1,21 +1,33 @@
 import type { FC } from 'react'
+import classNames from 'classnames'
 import { Popover } from '@/ui/component/popover/popover'
 import './dropDown.scss'
 
 export type DropDownProps = {
   trigger: JSX.Element
   content: JSX.Element
+  triggerClassName?: string
+  contentClassName?: string
 }
 
-export const DropDown: FC<DropDownProps> = ({ trigger, content }) => {
+export const DropDown: FC<DropDownProps> = ({
+  trigger,
+  content,
+  triggerClassName,
+  contentClassName
+}) => {
   return (
     <div className="okp4-dataverse-portal-dropdown-main">
       <Popover
         align="start"
         content={content}
-        contentClassName="okp4-dataverse-portal-dropdown-content"
+        contentClassName={classNames('okp4-dataverse-portal-dropdown-content', contentClassName)}
         sideOffset={8}
-        trigger={<div className="okp4-dataverse-portal-dropdown-field">{trigger}</div>}
+        trigger={
+          <div className={classNames('okp4-dataverse-portal-dropdown-field', triggerClassName)}>
+            {trigger}
+          </div>
+        }
         triggerClassName="okp4-dataverse-portal-dropdown-trigger"
         triggerIconName="chevron-sharp"
       />

--- a/src/ui/component/dropDown/multiselectDropDown.scss
+++ b/src/ui/component/dropDown/multiselectDropDown.scss
@@ -1,0 +1,94 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins.scss';
+
+.okp4-dataverse-portal-multiselect-dropdown-main {
+  @include with-theme {
+    .okp4-dataverse-portal-multiselect-dropdown-field-list {
+      display: flex;
+      gap: 10px;
+      width: 100%;
+
+      .okp4-dataverse-portal-multiselect-dropdown-field-list-item,
+      .okp4-dataverse-portal-multiselect-dropdown-field-list-additional-item {
+        color: themed('dropdown-tags-color');
+        background-color: themed('dropdown-tags-background');
+      }
+
+      .okp4-dataverse-portal-multiselect-dropdown-field-list-additional-item {
+        max-width: 40px; 
+      }
+
+      .okp4-dataverse-portal-multiselect-dropdown-field-list-item {
+        min-width: 40px;
+        flex-shrink: 0;
+      }
+
+      .hidden { 
+        display: none;
+      }
+    }
+  }
+}
+
+
+.okp4-dataverse-portal-multiselect-dropdown-options {
+  @include with-theme {
+    --checkbox-height: 32px;
+    --checkbox-gap: 6px;
+    --visible-checkboxes: 6;
+    --search-height: 40px;
+    --search-option-gap: 8px;
+    --search-option-padding: 10px;
+      
+    --content-height: calc(
+      (var(--checkbox-height) + var(--checkbox-gap)) * var(--visible-checkboxes) + var(--search-height) + var(--search-option-gap) + var(--search-option-padding) * 2
+    );
+    display: flex;
+    flex-direction: column;
+    height: var(--content-height);
+    max-height: auto;
+    padding: 0;
+    background-color: transparent;
+    box-shadow: none;
+      
+    .okp4-dataverse-portal-dropdown-search-options {
+      box-sizing: border-box;
+      padding: var(--search-option-padding);
+      @include columns-with-gap(var(--search-option-gap));
+      border-radius: 6px;
+      background-color: themed('dropdown-content-background');
+      box-shadow: themed('dropdown-content-box-shadow');
+      height: min-content;
+      max-height: 100%;
+        
+      .okp4-dataverse-portal-dropdown-options-list {
+        @include columns-with-gap(var(--checkbox-gap));
+        overflow-y: auto;
+        padding-right: var(--checkbox-gap);
+    
+        .checked {
+          background: none;
+        }
+      }
+    
+      .okp4-dataverse-portal-dropdown-no-results-wrapper {
+        @include grid-item($colStart: 1, $colEnd: -1);
+        display: flex;
+        justify-content: center;
+        height: inherit;
+        min-height: calc((var(--checkbox-height) + var(--checkbox-gap)) * 3);
+      }
+    }
+  }
+}
+
+.okp4-dataverse-portal-popover-content[data-side='top'] {
+  &.okp4-dataverse-portal-multiselect-dropdown-options {
+    justify-content: flex-end;
+  } 
+}
+    
+.okp4-dataverse-portal-popover-content[data-side='top'] .okp4-dataverse-portal-dropdown-search-options {
+  flex-direction: column-reverse;
+}

--- a/src/ui/component/dropDown/multiselectDropDown.tsx
+++ b/src/ui/component/dropDown/multiselectDropDown.tsx
@@ -139,11 +139,7 @@ export const MultiselectDropDown: FC<MultiselectDropDownProps> = ({
   return (
     <div className="okp4-dataverse-portal-multiselect-dropdown-main">
       <DropDown
-        field={
-          <MultiselectDropDownField onDelete={onChange} placeholder={placeholder} value={value} />
-        }
-        fieldClassName="okp4-dataverse-portal-multiselect-dropdown-field"
-        options={
+        content={
           <div className="okp4-dataverse-portal-dropdown-search-options">
             <SearchBar onSearch={handleSearch} placeholder={searchPlaceholder} value={searchTerm} />
             <MultiselectDropDownOptions
@@ -155,7 +151,11 @@ export const MultiselectDropDown: FC<MultiselectDropDownProps> = ({
             />
           </div>
         }
-        optionsClassName="okp4-dataverse-portal-multiselect-dropdown-options"
+        contentClassName="okp4-dataverse-portal-multiselect-dropdown-options"
+        trigger={
+          <MultiselectDropDownField onDelete={onChange} placeholder={placeholder} value={value} />
+        }
+        triggerClassName="okp4-dataverse-portal-multiselect-dropdown-field"
       />
     </div>
   )

--- a/src/ui/component/dropDown/multiselectDropDown.tsx
+++ b/src/ui/component/dropDown/multiselectDropDown.tsx
@@ -34,6 +34,13 @@ const MultiselectDropDownField: FC<MultiselectDropDownFieldProps> = ({
   onDelete,
   placeholder
 }) => {
+  const handleDelete = useCallback(
+    (value: string) => (): void => {
+      onDelete(value)
+    },
+    [onDelete]
+  )
+
   return value.length ? (
     <div className="okp4-dataverse-portal-multiselect-dropdown-field-list">
       {value.map((valueElement, index) => (
@@ -44,7 +51,7 @@ const MultiselectDropDownField: FC<MultiselectDropDownFieldProps> = ({
             }`
           }}
           key={valueElement}
-          onDelete={onDelete}
+          onDelete={handleDelete(valueElement)}
           tagName={valueElement}
         />
       ))}

--- a/src/ui/component/dropDown/multiselectDropDown.tsx
+++ b/src/ui/component/dropDown/multiselectDropDown.tsx
@@ -1,0 +1,162 @@
+import type { FC } from 'react'
+import { useMemo, useCallback, useState } from 'react'
+import { SearchBar } from '@/ui/component/searchbar/searchbar'
+import { isSubstringOf } from '@/util/util'
+import { Tag } from '@/ui/component/tag/tag'
+import { DynamicCheckbox } from '@/ui/view/dataverse/component/dynamicCheckbox/dynamicCheckbox'
+import { NoResultFound } from '@/ui/view/dataverse/component/noResultFound/noResultFound'
+import './dropDown.scss'
+import './multiselectDropDown.scss'
+import { DropDown } from './dropDown'
+
+type SelectionItemType = 'checkbox'
+
+export type MultiselectDropDownProps = {
+  placeholder: string
+  value: string[]
+  options: string[]
+  searchPlaceholder: string
+  selectionType: SelectionItemType
+  onChange: (value: string) => void
+  maxSearchResults?: number
+}
+
+const {
+  dropDown: { maxDisplayedSearchResults, maxDisplayedTags }
+} = APP_ENV
+
+type MultiselectDropDownFieldProps = Pick<MultiselectDropDownProps, 'value' | 'placeholder'> & {
+  onDelete: (value: string) => void
+}
+
+const MultiselectDropDownField: FC<MultiselectDropDownFieldProps> = ({
+  value,
+  onDelete,
+  placeholder
+}) => {
+  return value.length ? (
+    <div className="okp4-dataverse-portal-multiselect-dropdown-field-list">
+      {value.map((valueElement, index) => (
+        <Tag
+          classes={{
+            main: `okp4-dataverse-portal-multiselect-dropdown-field-list-item ${
+              maxDisplayedTags <= index && 'hidden'
+            }`
+          }}
+          key={valueElement}
+          onDelete={onDelete}
+          tagName={valueElement}
+        />
+      ))}
+      {value.length - maxDisplayedTags > 0 && (
+        <Tag
+          classes={{
+            main: 'okp4-dataverse-portal-multiselect-dropdown-field-list-additional-item'
+          }}
+          tagName={`+${value.length - maxDisplayedTags}`}
+        />
+      )}
+    </div>
+  ) : (
+    <p className="okp4-dataverse-portal-dropdown-field-placeholder">{placeholder}</p>
+  )
+}
+
+type MultiselectDropDownOptionsProps = Pick<MultiselectDropDownProps, 'selectionType' | 'value'> & {
+  foundOptions: string[]
+  searchTerm: string
+  onChange: (value: string) => void
+}
+
+const MultiselectDropDownOptions: FC<MultiselectDropDownOptionsProps> = ({
+  foundOptions,
+  selectionType,
+  searchTerm,
+  value,
+  onChange
+}) => {
+  const handleChange = useCallback(
+    ({ value }: { value: string }): void => {
+      onChange(value)
+    },
+    [onChange]
+  )
+
+  return (
+    <div className="okp4-dataverse-portal-dropdown-options-list">
+      {foundOptions.length ? (
+        foundOptions.map(option => {
+          switch (selectionType) {
+            case 'checkbox':
+              return (
+                <DynamicCheckbox
+                  checked={value.includes(option)}
+                  highlightedTerm={searchTerm}
+                  key={option}
+                  name={option}
+                  onCheckedChange={handleChange}
+                  value={option}
+                />
+              )
+          }
+        })
+      ) : (
+        <NoResultFound
+          className="okp4-dataverse-portal-dropdown-no-results-wrapper"
+          iconName="large-magnifier-with-cross"
+        />
+      )}
+    </div>
+  )
+}
+
+export const MultiselectDropDown: FC<MultiselectDropDownProps> = ({
+  placeholder,
+  value,
+  options,
+  onChange,
+  searchPlaceholder,
+  selectionType,
+  maxSearchResults = maxDisplayedSearchResults
+}) => {
+  const [searchTerm, setSearchTerm] = useState<string>('')
+
+  const handleSearch = useCallback(
+    (searchTerm: string) => {
+      setSearchTerm(searchTerm)
+    },
+    [setSearchTerm]
+  )
+
+  const foundOptions = useMemo(
+    () =>
+      searchTerm.trim() === ''
+        ? options.slice(0, maxSearchResults)
+        : options.filter(option => isSubstringOf(searchTerm, option)).slice(0, maxSearchResults),
+    [options, searchTerm, maxSearchResults]
+  )
+
+  return (
+    <div className="okp4-dataverse-portal-multiselect-dropdown-main">
+      <DropDown
+        field={
+          <MultiselectDropDownField onDelete={onChange} placeholder={placeholder} value={value} />
+        }
+        fieldClassName="okp4-dataverse-portal-multiselect-dropdown-field"
+        options={
+          <div className="okp4-dataverse-portal-dropdown-search-options">
+            <SearchBar onSearch={handleSearch} placeholder={searchPlaceholder} value={searchTerm} />
+            <MultiselectDropDownOptions
+              foundOptions={foundOptions}
+              onChange={onChange}
+              searchTerm={searchTerm}
+              selectionType={selectionType}
+              value={value}
+            />
+          </div>
+        }
+        optionsClassName="okp4-dataverse-portal-multiselect-dropdown-options"
+      />
+    </div>
+  )
+}

--- a/src/ui/component/tag/tag.tsx
+++ b/src/ui/component/tag/tag.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames'
 type TagProps = {
   tagName: string
   classes?: { main?: string; name?: string; icon?: string }
-  onDelete?: (tagName: string) => void
+  onDelete?: () => void
 }
 
 export const Tag: FC<TagProps> = ({ tagName, onDelete, classes }) => {
@@ -20,10 +20,10 @@ export const Tag: FC<TagProps> = ({ tagName, onDelete, classes }) => {
       e.stopPropagation()
 
       if (onDelete) {
-        onDelete(tagName)
+        onDelete()
       }
     },
-    [onDelete, tagName]
+    [onDelete]
   )
 
   return (

--- a/src/ui/component/tag/tag.tsx
+++ b/src/ui/component/tag/tag.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames'
 type TagProps = {
   tagName: string
   classes?: { main?: string; name?: string; icon?: string }
-  onDelete?: () => void
+  onDelete?: (tagName: string) => void
 }
 
 export const Tag: FC<TagProps> = ({ tagName, onDelete, classes }) => {
@@ -20,10 +20,10 @@ export const Tag: FC<TagProps> = ({ tagName, onDelete, classes }) => {
       e.stopPropagation()
 
       if (onDelete) {
-        onDelete()
+        onDelete(tagName)
       }
     },
-    [onDelete]
+    [onDelete, tagName]
   )
 
   return (

--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.scss
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.scss
@@ -60,7 +60,7 @@
           }
         }
 
-        p {
+        .okp4-dataverse-portal-share-data-metadata-filling-legend {
           @include noto-sans(700);
           color: themed('text');
           font-size: 14px;

--- a/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
+++ b/src/ui/page/share/dataset/steps/metadataFilling/metadataFilling.tsx
@@ -18,9 +18,10 @@ import { TextField } from '@/ui/component/field/textField'
 import type { NotificationType } from '@/ui/component/notification/notification'
 import { useDispatchNotification } from '@/ui/hook/useDispatchNotification'
 import { TagsField } from '@/ui/view/tagsField/tagsField'
-import './metadataFilling.scss'
 import { NumericField } from '@/ui/component/field/numericField'
 import { KnowFee } from '@/ui/view/share/knowFee/knowFee'
+import { MultiselectDropDown } from '@/ui/component/dropDown/multiselectDropDown'
+import './metadataFilling.scss'
 
 type FormItemBaseProps = {
   id: string
@@ -154,6 +155,26 @@ export const MetadataFilling: FC = () => {
     [formItemById]
   )
 
+  // TODO: fetch default options from ontology
+  // and use them as default values in the slice
+  const defaultFormatOption = useMemo(
+    () => [
+      'option1',
+      'option2',
+      'option3',
+      'option4',
+      'option5',
+      'option6',
+      'option7',
+      'option8',
+      'option9',
+      'option10',
+      'option11',
+      'option12'
+    ],
+    []
+  )
+
   const multiValuesField = useCallback(
     (id: string): string[] =>
       pipe(
@@ -268,17 +289,21 @@ export const MetadataFilling: FC = () => {
       },
       {
         id: id5,
-        type: 'text',
+        type: 'select',
         title: 'format',
         value: O.none,
         render: (): JSX.Element => (
           <div className="okp4-dataverse-portal-share-data-metadata-filling" key={id5}>
-            <p>{t('share.metadataFilling.format')}</p>
-            <TextField
-              id={id5}
-              label={t('share.metadataFilling.formatSelection')}
-              onChange={handleFieldValueChange(id5)}
-              value={textValueField(id5)}
+            <p className="okp4-dataverse-portal-share-data-metadata-filling-legend">
+              {t('share.metadataFilling.format')}
+            </p>
+            <MultiselectDropDown
+              onChange={handleTagsFieldValueChange(id5)}
+              options={defaultFormatOption}
+              placeholder={t('share.metadataFilling.formatSelection')}
+              searchPlaceholder={t('share.metadataFilling.formatSelection')}
+              selectionType="checkbox"
+              value={multiValuesField(id5)}
             />
           </div>
         ),
@@ -288,17 +313,21 @@ export const MetadataFilling: FC = () => {
       },
       {
         id: id6,
-        type: 'text',
+        type: 'select',
         title: 'license',
         value: O.none,
         render: (): JSX.Element => (
           <div className="okp4-dataverse-portal-share-data-metadata-filling" key={id6}>
-            <p>{t('share.metadataFilling.license')}</p>
-            <TextField
-              id={id6}
-              label={t('share.metadataFilling.licenceSelection')}
-              onChange={handleFieldValueChange(id6)}
-              value={textValueField(id6)}
+            <p className="okp4-dataverse-portal-share-data-metadata-filling-legend">
+              {t('share.metadataFilling.license')}
+            </p>
+            <MultiselectDropDown
+              onChange={handleTagsFieldValueChange(id6)}
+              options={defaultFormatOption}
+              placeholder={t('share.metadataFilling.licenceSelection')}
+              searchPlaceholder={t('share.metadataFilling.licenceSelection')}
+              selectionType="checkbox"
+              value={multiValuesField(id6)}
             />
           </div>
         ),
@@ -313,7 +342,9 @@ export const MetadataFilling: FC = () => {
         value: O.none,
         render: (): JSX.Element => (
           <div className="okp4-dataverse-portal-share-data-metadata-filling" key={id7}>
-            <p>{t('share.metadataFilling.topic')}</p>
+            <p className="okp4-dataverse-portal-share-data-metadata-filling-legend">
+              {t('share.metadataFilling.topic')}
+            </p>
             <TextField
               id={id7}
               label={t('share.metadataFilling.topicSelection')}
@@ -333,7 +364,9 @@ export const MetadataFilling: FC = () => {
         value: O.none,
         render: (): JSX.Element => (
           <div className="okp4-dataverse-portal-share-data-metadata-filling" key={id8}>
-            <p>{t('share.metadataFilling.geographicalCoverage')}</p>
+            <p className="okp4-dataverse-portal-share-data-metadata-filling-legend">
+              {t('share.metadataFilling.geographicalCoverage')}
+            </p>
             <TextField
               id={id8}
               label={t('share.metadataFilling.geographicalCoverageSelection')}
@@ -353,7 +386,9 @@ export const MetadataFilling: FC = () => {
         value: O.none,
         render: (): JSX.Element => (
           <div className="okp4-dataverse-portal-share-data-metadata-filling" key={id9}>
-            <p>{t('share.metadataFilling.tags')}</p>
+            <p className="okp4-dataverse-portal-share-data-metadata-filling-legend">
+              {t('share.metadataFilling.tags')}
+            </p>
             <TagsField
               addTag={handleTagsFieldValueChange(id9)}
               removeTag={handleTagsFieldValueChange(id9)}
@@ -404,7 +439,8 @@ export const MetadataFilling: FC = () => {
     numericValueField,
     multiValuesField,
     handleNumericValueChange,
-    handleTagsFieldValueChange
+    handleTagsFieldValueChange,
+    defaultFormatOption
   ])
 
   const mapForm = (form: DatasetForm): InitFormPayload =>


### PR DESCRIPTION
## Purpose
This PR add the **multiselect** variant of dropdown component. This is a reusable component, used for _format_ and _license_ field in the step3 of share data (see Figma's step 3 screenshot below).
<img width="646" alt="image" src="https://github.com/okp4/dataverse-portal/assets/8344874/be0c1d3e-0d3c-47a9-9da1-159b326b01d2">

## Testing
Update the `shareDataset.tsx` file  by only using the step 3, as follow. Then go to `http://localhost:5173/share/data`.
```tsx
import type { FC } from 'react'
import { useTranslation } from 'react-i18next'
import { MetadataFilling } from './steps/metadataFilling/metadataFilling'
import { Stepper } from '@/ui/component/stepper/stepper'
import type { StepElement } from '@/ui/component/stepper/stepper'
import '../i18n/index'
import './shareDataset.scss'

export const ShareDataset: FC = () => {
  const { t } = useTranslation('share')
  const metadataFilling: StepElement = { id: 'step3', content: <MetadataFilling /> }

  const steps = [metadataFilling]

  return (
    <div className="okp4-dataverse-portal-share-dataset-page-main">
      <h1>{t('share.dataset.title')}</h1>
      <Stepper steps={steps} />
    </div>
  )
}

```
## Limitation of the current implementation
When the displayed dropdown tags elements are very large, we can end with an overflow. To solve this edge case and make the component more robust, we would prefer to compute tags widths and field width in order to always display the right amount of tags, instead of relying on the `maxDisplayedTags` constant.

This edge case will be handled in a second iteration.
