### PR TITLE
feat(governance): add paragraph see more modal pop up

### DIFF
--- a/src/ui/component/button/button.scss
+++ b/src/ui/component/button/button.scss
@@ -228,8 +228,7 @@
       }
 
       &.primary-discreet,
-      &.secondary-discreet,
-      &.outlined-secondary {
+      &.secondary-discreet {
         padding: 4px 8px;
         gap: 10px;
       }

--- a/src/ui/view/governance/details/details.scss
+++ b/src/ui/view/governance/details/details.scss
@@ -173,6 +173,27 @@
   }
 }
 
+.okp4-dataverse-portal-governance-details-modal-top-element {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  h1 {
+    @include norse-font(700);
+    font-size: 24px;
+  }
+}
+
+.okp4-dataverse-portal-governance-details-modal-content {
+  @include noto-sans(400);
+  max-width: 293px;
+  overflow-wrap: break-word;
+}
+
+.okp4-dataverse-portal-governance-details-modal-button {
+  width: 120px !important;
+}
+
 .okp4-dataverse-portal-governance-identity-main {
   @include with-theme {
     @include noto-sans(700);

--- a/src/ui/view/governance/details/details.scss
+++ b/src/ui/view/governance/details/details.scss
@@ -173,26 +173,31 @@
   }
 }
 
-.okp4-dataverse-portal-governance-details-modal-top-element {
-  display: flex;
-  gap: 6px;
-  align-items: center;
+.okp4-dataverse-portal-governance-details-modal-main {
+  .okp4-dataverse-portal-governance-details-modal-top-element {
+    display: flex;
+    gap: 6px;
+    align-items: center;
 
-  h1 {
-    @include norse-font(700);
-    font-size: 24px;
+    .okp4-dataverse-portal-governance-details-modal-top-element-title {
+      @include norse-font(700);
+      font-size: 24px;
+    }
+  }
+
+  .okp4-dataverse-portal-governance-details-modal-content {
+    @include noto-sans(400);
+    max-width: 293px;
+    overflow-wrap: break-word;
+  }
+
+  .okp4-dataverse-portal-okp4-modal-bottom-element {
+    .okp4-dataverse-portal-governance-details-modal-button {
+      width: 120px;
+    }
   }
 }
-
-.okp4-dataverse-portal-governance-details-modal-content {
-  @include noto-sans(400);
-  max-width: 293px;
-  overflow-wrap: break-word;
-}
-
-.okp4-dataverse-portal-governance-details-modal-button {
-  width: 120px !important;
-}
+  
 
 .okp4-dataverse-portal-governance-identity-main {
   @include with-theme {

--- a/src/ui/view/governance/details/details.tsx
+++ b/src/ui/view/governance/details/details.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@/ui/page/dataverse/zone/governance/mockedData'
 import classNames from 'classnames'
 import './details.scss'
+import { Okp4Modal } from '../../modal/okp4-modal'
 
 type ArticleProps = {
   article: ArticleDTO
@@ -54,6 +55,16 @@ const Paragraph: FC<ParagraphProps> = ({ paragraph, theme }) => {
     }
   }, [])
 
+  const [isModalOpen, setModalOpen] = useState(false)
+
+  const handleOpenModal = useCallback(() => {
+    setModalOpen(true)
+  }, [])
+
+  const handleCloseModal = useCallback(() => {
+    setModalOpen(false)
+  }, [])
+
   return (
     <div className="okp4-dataverse-portal-governance-details-paragraph">
       <Icon name={`${iconMapping[paragraph.title] || 'description'}-${theme}` as IconName} />
@@ -68,9 +79,36 @@ const Paragraph: FC<ParagraphProps> = ({ paragraph, theme }) => {
       </div>
       {isTextTooLong && (
         <div className="okp4-dataverse-portal-governance-details-button">
-          <Button disabled label={t('actions.seeMore')} variant="outlined-tertiary" />
+          <Button
+            label={t('actions.seeMore')}
+            onClick={handleOpenModal}
+            variant="outlined-tertiary"
+          />
         </div>
       )}
+      <Okp4Modal
+        bottomElement={
+          <Button
+            className="okp4-dataverse-portal-governance-details-modal-button"
+            label={t('actions.close')}
+            onClick={handleCloseModal}
+            size="large"
+            variant="outlined-secondary"
+          />
+        }
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        topElement={
+          <div className="okp4-dataverse-portal-governance-details-modal-top-element">
+            <Icon name={`${iconMapping[paragraph.title] || 'description'}-${theme}` as IconName} />
+            <h1>{paragraph.title}</h1>
+          </div>
+        }
+      >
+        <div className="okp4-dataverse-portal-governance-details-modal-content">
+          {paragraph.description}
+        </div>
+      </Okp4Modal>
     </div>
   )
 }

--- a/src/ui/view/governance/details/details.tsx
+++ b/src/ui/view/governance/details/details.tsx
@@ -11,9 +11,9 @@ import type {
   ParagraphDTO,
   SectionDTO
 } from '@/ui/page/dataverse/zone/governance/mockedData'
+import { Okp4Modal } from '@/ui/view/modal/okp4-modal'
 import classNames from 'classnames'
 import './details.scss'
-import { Okp4Modal } from '../../modal/okp4-modal'
 
 type ArticleProps = {
   article: ArticleDTO
@@ -96,12 +96,17 @@ const Paragraph: FC<ParagraphProps> = ({ paragraph, theme }) => {
             variant="outlined-secondary"
           />
         }
+        classes={{
+          main: 'okp4-dataverse-portal-governance-details-modal-main'
+        }}
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         topElement={
           <div className="okp4-dataverse-portal-governance-details-modal-top-element">
             <Icon name={`${iconMapping[paragraph.title] || 'description'}-${theme}` as IconName} />
-            <h1>{paragraph.title}</h1>
+            <h1 className="okp4-dataverse-portal-governance-details-modal-top-element-title">
+              {paragraph.title}
+            </h1>
           </div>
         }
       >

--- a/src/ui/view/modal/okp4-modal.scss
+++ b/src/ui/view/modal/okp4-modal.scss
@@ -16,6 +16,8 @@
     .okp4-dataverse-portal-okp4-modal-top-element {
       min-height: 66px;
       padding: 12px 12px 0;
+      display: flex;
+      align-items: center;
     }
 
     .okp4-dataverse-portal-okp4-modal-top-element-divider {
@@ -37,6 +39,8 @@
     .okp4-dataverse-portal-okp4-modal-bottom-element {
       min-height: 66px;
       padding: 0 12px 12px;
+      display: flex;
+      align-items: center;
     }
   }
 }


### PR DESCRIPTION
This PR implements a modal pop up in the governance page when the user clicks the `See more` button (when the paragraph content cannot fit in the cards).

## Screenshots

<img width="938" alt="image" src="https://github.com/okp4/dataverse-portal/assets/83208740/d21de970-7543-4a2f-b713-a211d55114d3">

<img width="934" alt="image" src="https://github.com/okp4/dataverse-portal/assets/83208740/14468eae-9a2b-45a6-ae74-1bdd2dd73451">


## Notes
🚨 DID detection, copy and styling will be handled in a different PR. For now the DID displaying in the pop up is not the same as in the mockups since the DID detection has not been implemented yet