### PR TITLE
Feat/improve tags field scrollbar display

### DIFF
--- a/src/ui/view/tagsField/tagsField.scss
+++ b/src/ui/view/tagsField/tagsField.scss
@@ -5,57 +5,60 @@
 .okp4-dataverse-portal-tags-field-main {
   $tag-height: 28px;
   @include with-theme() {
-    box-sizing: border-box;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
     padding: 10px;
-    max-height: 86px;
-    overflow-y: auto;
-    width: 100%;
     border-radius: 10px;
     background-color: themed('card');
+    
+    .okp4-dataverse-portal-tags-field-content {
+      box-sizing: border-box;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      max-height: 66px;
+      overflow-y: auto;
+      width: 100%;
 
-    .okp4-dataverse-portal-tag-main {
-      min-height: $tag-height;
-    }
-
-    .okp4-dataverse-portal-tags-field {
-      position: relative;
-      height: $tag-height;
-
-      .okp4-dataverse-portal-tags-field-placeholder {
-        visibility: visible;
-        @include rows-with-gap(4px);
-        align-items: center;
-        pointer-events: none;
-        height: inherit;
-        @include noto-sans(400);
-        color: rgba(themed('text'), 0.6);
-        font-size: 16px;
-        line-height: 22px;
-
-        .okp4-dataverse-portal-tags-field-placeholder-action {
-          padding: 0 4px;
-          border-radius: 2px;
-          background-color: themed('tags-field-input-action-background');
-        }
-
-        &.hidden {
-          visibility: hidden;
-        }
+      .okp4-dataverse-portal-tag-main {
+        min-height: $tag-height;
       }
 
-      .okp4-dataverse-portal-tags-field-input {
-        position: absolute;
-        inset: 0;
-        @include noto-sans(400);
-        font-size: 16px;
-        line-height: 22px;
-        color: themed('text');
-        background-color: transparent;
-        border: 0;
-        outline: 0;
+      .okp4-dataverse-portal-tags-field {
+        position: relative;
+        height: $tag-height;
+
+        .okp4-dataverse-portal-tags-field-placeholder {
+          visibility: visible;
+          @include rows-with-gap(4px);
+          align-items: center;
+          pointer-events: none;
+          height: inherit;
+          @include noto-sans(400);
+          color: rgba(themed('text'), 0.6);
+          font-size: 16px;
+          line-height: 22px;
+
+          .okp4-dataverse-portal-tags-field-placeholder-action {
+            padding: 0 4px;
+            border-radius: 2px;
+            background-color: themed('tags-field-input-action-background');
+          }
+
+          &.hidden {
+            visibility: hidden;
+          }
+        }
+
+        .okp4-dataverse-portal-tags-field-input {
+          position: absolute;
+          inset: 0;
+          @include noto-sans(400);
+          font-size: 16px;
+          line-height: 22px;
+          color: themed('text');
+          background-color: transparent;
+          border: 0;
+          outline: 0;
+        }
       }
     }
   }

--- a/src/ui/view/tagsField/tagsField.tsx
+++ b/src/ui/view/tagsField/tagsField.tsx
@@ -45,25 +45,29 @@ export const TagsField: FC<TagsFieldProps> = ({ tags, addTag, removeTag }) => {
 
   return (
     <div className="okp4-dataverse-portal-tags-field-main">
-      {tags.map((tag: string, index: number) => (
-        <Tag key={`${tag}-${index}`} onDelete={handleDelete(tag)} tagName={tag} />
-      ))}
-      <div className="okp4-dataverse-portal-tags-field">
-        <span
-          className={classNames('okp4-dataverse-portal-tags-field-placeholder', {
-            hidden: inputValue
-          })}
-        >
-          {t('typeAndPress')}
-          <span className="okp4-dataverse-portal-tags-field-placeholder-action">{t('enter')}</span>
-        </span>
-        <input
-          className="okp4-dataverse-portal-tags-field-input"
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          type="text"
-          value={inputValue}
-        />
+      <div className="okp4-dataverse-portal-tags-field-content">
+        {tags.map((tag: string, index: number) => (
+          <Tag key={`${tag}-${index}`} onDelete={handleDelete(tag)} tagName={tag} />
+        ))}
+        <div className="okp4-dataverse-portal-tags-field">
+          <span
+            className={classNames('okp4-dataverse-portal-tags-field-placeholder', {
+              hidden: inputValue
+            })}
+          >
+            {t('typeAndPress')}
+            <span className="okp4-dataverse-portal-tags-field-placeholder-action">
+              {t('enter')}
+            </span>
+          </span>
+          <input
+            className="okp4-dataverse-portal-tags-field-input"
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            type="text"
+            value={inputValue}
+          />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Purpose
Properly display scrollbar for share data tags field.
Tags are wrapped in an intermediate html element.

![image](https://github.com/okp4/dataverse-portal/assets/8344874/2e4aac77-4d66-4c56-bce5-942329e292b4)
