### PR TITLE
Feat/make popover component controlled

### DIFF
--- a/src/ui/component/dropDown/dropDown.tsx
+++ b/src/ui/component/dropDown/dropDown.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import { useCallback, type FC, useState } from 'react'
 import classNames from 'classnames'
 import { Popover } from '@/ui/component/popover/popover'
 import './dropDown.scss'
@@ -16,12 +16,20 @@ export const DropDown: FC<DropDownProps> = ({
   triggerClassName,
   contentClassName
 }) => {
+  const [open, setOpen] = useState(false)
+
+  const handleOpenChange = useCallback(() => {
+    setOpen(state => !state)
+  }, [])
+
   return (
     <div className="okp4-dataverse-portal-dropdown-main">
       <Popover
         align="start"
         content={content}
         contentClassName={classNames('okp4-dataverse-portal-dropdown-content', contentClassName)}
+        onOpenChange={handleOpenChange}
+        open={open}
         sideOffset={8}
         trigger={
           <div className={classNames('okp4-dataverse-portal-dropdown-field', triggerClassName)}>

--- a/src/ui/component/popover/popover.tsx
+++ b/src/ui/component/popover/popover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import type { FC } from 'react'
 import classNames from 'classnames'
 import * as RPopover from '@radix-ui/react-popover'
@@ -9,6 +9,7 @@ import './popover.scss'
 type PopoverProps = Omit<RPopover.PopoverContentProps, 'content'> & {
   content: JSX.Element
   trigger: JSX.Element
+  onOpenChange?: () => void
   open?: boolean
   contentClassName?: string
   triggerClassName?: string
@@ -24,9 +25,9 @@ export const Popover: FC<PopoverProps> = ({
   triggerClassName,
   triggerIconName,
   container,
+  onOpenChange,
   ...contentProps
 }) => {
-  const [isOpen, setIsOpen] = useState(open)
   const containerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
@@ -34,7 +35,7 @@ export const Popover: FC<PopoverProps> = ({
   }, [container])
 
   return (
-    <RPopover.Root onOpenChange={setIsOpen} open={isOpen}>
+    <RPopover.Root onOpenChange={onOpenChange} open={open}>
       <RPopover.Trigger
         className={classNames('okp4-dataverse-portal-popover-trigger-button', triggerClassName)}
       >
@@ -42,7 +43,7 @@ export const Popover: FC<PopoverProps> = ({
         {triggerIconName && (
           <div
             className={classNames('okp4-dataverse-portal-popover-trigger-icon', {
-              flipped: isOpen
+              flipped: open
             })}
           >
             <Icon name={triggerIconName} />


### PR DESCRIPTION
## Purpose
Allow to control the Popover component `open` state from other triggers than the built-in `Trigger` element. It provides more flexibility, e. g. closing the popover from an element from it's content.
This update is helpful in the context of the DatePicker component.

It also remove the derived `isOpen` state from props, which is not an idiomatic React approach.

DropDown component that uses Popover has been updated accordingly.