### PR TITLE
Feat/add metadata domain

### DIFF
--- a/src/domain/metadata/command.ts
+++ b/src/domain/metadata/command.ts
@@ -1,0 +1,22 @@
+import type { IO } from 'fp-ts/lib/IO'
+import type { ReaderTaskEither } from 'fp-ts/lib/ReaderTaskEither'
+import type { MetadataPort } from './port'
+
+type DataverseItemId = string
+
+// TODO: add metadata errors
+export type LoadMetadataError = ErrorOptions
+
+export type Deps = {
+  metadataPort: MetadataPort
+  language: string
+}
+
+export type Command = {
+  // Load dataverse item general and audit metadata from outside
+  retrieveDataverseItemMetadata: (
+    dataverseItemId: DataverseItemId
+  ) => ReaderTaskEither<Deps, LoadMetadataError, void>
+  // Set the language in which the metadata should be translated to
+  setLanguage: (newLng: string) => IO<void>
+}

--- a/src/domain/metadata/command.ts
+++ b/src/domain/metadata/command.ts
@@ -1,4 +1,3 @@
-import type { IO } from 'fp-ts/lib/IO'
 import type { ReaderTaskEither } from 'fp-ts/lib/ReaderTaskEither'
 import type { MetadataPort } from './port'
 
@@ -17,6 +16,4 @@ export type Command = {
   retrieveDataverseItemMetadata: (
     dataverseItemId: DataverseItemId
   ) => ReaderTaskEither<Deps, LoadMetadataError, void>
-  // Set the language in which the metadata should be translated to
-  setLanguage: (newLng: string) => IO<void>
 }

--- a/src/domain/metadata/command.ts
+++ b/src/domain/metadata/command.ts
@@ -1,10 +1,11 @@
 import type { ReaderTaskEither } from 'fp-ts/lib/ReaderTaskEither'
 import type { MetadataPort } from './port'
+import type { SerializationError } from '@/shared/error/serialize'
+import type { NetworkError } from '@/shared/error/network'
 
 type DataverseItemId = string
 
-// TODO: add metadata errors
-export type LoadMetadataError = ErrorOptions
+export type LoadMetadataError = SerializationError | NetworkError
 
 export type Deps = {
   metadataPort: MetadataPort

--- a/src/domain/metadata/domain.ts
+++ b/src/domain/metadata/domain.ts
@@ -5,7 +5,6 @@ import { devtools } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 import * as O from 'fp-ts/Option'
 import * as A from 'fp-ts/Array'
-import type IO from 'fp-ts/IO'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import { flow, pipe } from 'fp-ts/function'
 import type { ForgetType } from '@/util/type'
@@ -95,31 +94,7 @@ export const storeFactory = ({ initialState }: Partial<Options> = {}): StoreApi<
                 )
               )
             )
-          ),
-        setLanguage: (newLng: string): IO.IO<void> => {
-          console.log({ newLng })
-          return pipe(
-            newLng,
-            O.fromPredicate(lng => !!lng.length),
-            O.match(
-              () => () =>
-                set(state => ({
-                  data: {
-                    ...state.data,
-                    error: O.some(
-                      new Error(
-                        `Oops.. An error occurred in <setLanguage> call.. Parameter cannot be empty: <${newLng}>..`
-                      )
-                    )
-                  }
-                })),
-              language => () =>
-                set(state => ({
-                  data: { ...state.data, metadata: [], language }
-                }))
-            )
           )
-        }
       })),
       {
         anonymousActionType: 'Aggregate',

--- a/src/domain/metadata/domain.ts
+++ b/src/domain/metadata/domain.ts
@@ -1,0 +1,130 @@
+/* eslint-disable max-lines-per-function */
+import { createStore } from 'zustand'
+import type { StoreApi } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+import * as O from 'fp-ts/Option'
+import * as A from 'fp-ts/Array'
+import type IO from 'fp-ts/IO'
+import * as RTE from 'fp-ts/ReaderTaskEither'
+import { flow, pipe } from 'fp-ts/function'
+import type { ForgetType } from '@/util/type'
+import type { AuditMetadataItem, GeneralMetadataItem, Metadata, MetadataItem } from './entity'
+import type { Query } from './query'
+import type { Command, Deps } from './command'
+import { isDevMode } from '@/util/env.util'
+
+type State = {
+  data: Metadata
+}
+
+type Domain = State & Command & Query
+export type DomainAPI = ForgetType<State, Domain>
+
+export type Options = {
+  initialState: State
+}
+const isAuditMetadataItem = (metadataItem: MetadataItem): metadataItem is AuditMetadataItem =>
+  metadataItem.category === 'auditMetadata'
+
+const isGeneralMetadataItem = (metadataItem: MetadataItem): metadataItem is GeneralMetadataItem =>
+  metadataItem.category === 'generalMetadata'
+
+export const storeFactory = ({ initialState }: Partial<Options> = {}): StoreApi<DomainAPI> =>
+  createStore(
+    devtools(
+      immer<Domain>((set, get) => ({
+        data: pipe(
+          initialState,
+          O.fromNullable,
+          O.map(it => it.data),
+          O.getOrElse<Metadata>(() => ({
+            data: [],
+            isLoading: false
+          }))
+        ),
+        isLoading: () => () => get().data.isLoading,
+        auditMetadata: () => () =>
+          pipe(
+            get().data.data,
+            A.filter(isAuditMetadataItem),
+            A.map(auditMetadata => ({
+              property: auditMetadata.property,
+              value: auditMetadata.value
+            }))
+          ),
+        generalMetadata: () => () =>
+          pipe(
+            get().data.data,
+            A.filter(isGeneralMetadataItem),
+            A.map(generalMetadata => ({
+              property: generalMetadata.property,
+              value: generalMetadata.value
+            }))
+          ),
+        retrieveDataverseItemMetadata: dataverseItemId =>
+          pipe(
+            RTE.ask<Deps>(),
+            RTE.flatMap(deps =>
+              pipe(
+                RTE.fromIO(() =>
+                  set(state => ({
+                    data: {
+                      ...state.data,
+                      isLoading: true
+                    }
+                  }))
+                ),
+                RTE.chainTaskEitherK(() =>
+                  deps.metadataPort.retrieveMetadata(dataverseItemId, deps.language)
+                ),
+                RTE.tapError(
+                  flow(
+                    RTE.left,
+                    RTE.tapError(() =>
+                      RTE.fromIO(() =>
+                        set(state => ({
+                          data: { ...state.data, isLoading: false }
+                        }))
+                      )
+                    )
+                  )
+                ),
+                RTE.chainIOK(
+                  metadata => () => set(() => ({ data: { data: metadata, isLoading: false } }))
+                )
+              )
+            )
+          ),
+        setLanguage: (newLng: string): IO.IO<void> => {
+          console.log({ newLng })
+          return pipe(
+            newLng,
+            O.fromPredicate(lng => !!lng.length),
+            O.match(
+              () => () =>
+                set(state => ({
+                  data: {
+                    ...state.data,
+                    error: O.some(
+                      new Error(
+                        `Oops.. An error occurred in <setLanguage> call.. Parameter cannot be empty: <${newLng}>..`
+                      )
+                    )
+                  }
+                })),
+              language => () =>
+                set(state => ({
+                  data: { ...state.data, metadata: [], language }
+                }))
+            )
+          )
+        }
+      })),
+      {
+        anonymousActionType: 'Aggregate',
+        name: 'metadata',
+        enabled: isDevMode()
+      }
+    )
+  )

--- a/src/domain/metadata/entity.ts
+++ b/src/domain/metadata/entity.ts
@@ -1,0 +1,41 @@
+export type AuditMetadataProperty = 'createdBy' | 'createdOn' | 'lastModifiedBy' | 'updatedOn'
+export type GeneralMetadataProperty =
+  | 'category'
+  | 'creator'
+  | 'description'
+  | 'format'
+  | 'image'
+  | 'license'
+  | 'publisher'
+  | 'spatialCoverage'
+  | 'tags'
+  | 'temporalCoverage'
+  | 'title'
+  | 'topic'
+
+export type MetadataProperty = GeneralMetadataProperty | AuditMetadataProperty
+
+export type Category = 'generalMetadata' | 'auditMetadata'
+
+export type AuditMetadataItem = {
+  category: 'auditMetadata'
+  property: AuditMetadataProperty
+  value: string
+}
+
+export type GeneralMetadataItem = {
+  category: 'generalMetadata'
+  property: GeneralMetadataProperty
+  value: string | string[] | [string, string]
+}
+
+export type MetadataItem = {
+  category: Category
+  property: MetadataProperty
+  value: string | string[] | [string, string]
+}
+
+export type Metadata = {
+  data: MetadataItem[]
+  isLoading: boolean
+}

--- a/src/domain/metadata/port.ts
+++ b/src/domain/metadata/port.ts
@@ -1,0 +1,12 @@
+import type * as TE from 'fp-ts/TaskEither'
+import type { MetadataItem } from './entity'
+
+type DataverseItemId = string
+
+export type MetadataPort = {
+  // TODO: add metadata errors
+  retrieveMetadata: (
+    dataverseItemId: DataverseItemId,
+    language: string
+  ) => TE.TaskEither<Error, MetadataItem[]>
+}

--- a/src/domain/metadata/port.ts
+++ b/src/domain/metadata/port.ts
@@ -1,12 +1,15 @@
 import type * as TE from 'fp-ts/TaskEither'
 import type { MetadataItem } from './entity'
+import type { NetworkError } from '@/shared/error/network'
+import type { SerializationError } from '@/shared/error/serialize'
 
 type DataverseItemId = string
 
+export type LoadMetadataError = SerializationError | NetworkError
+
 export type MetadataPort = {
-  // TODO: add metadata errors
   retrieveMetadata: (
     dataverseItemId: DataverseItemId,
     language: string
-  ) => TE.TaskEither<Error, MetadataItem[]>
+  ) => TE.TaskEither<LoadMetadataError, MetadataItem[]>
 }

--- a/src/domain/metadata/query.ts
+++ b/src/domain/metadata/query.ts
@@ -1,0 +1,35 @@
+import type { IO } from 'fp-ts/lib/IO'
+
+export type AuditMetadataProperty = 'createdBy' | 'createdOn' | 'lastModifiedBy' | 'updatedOn'
+export type GeneralMetadataProperty =
+  | 'category'
+  | 'creator'
+  | 'description'
+  | 'format'
+  | 'image'
+  | 'license'
+  | 'publisher'
+  | 'spatialCoverage'
+  | 'tags'
+  | 'temporalCoverage'
+  | 'title'
+  | 'topic'
+
+export type GeneralMetadataItem = {
+  property: GeneralMetadataProperty
+  value: string | string[] | [string, string]
+}
+
+export type AuditMetadataItem = {
+  property: AuditMetadataProperty
+  value: string
+}
+
+export type Query = {
+  // Get the dataverse item audit metadata
+  auditMetadata: () => IO<AuditMetadataItem[]>
+  // Get the dataverse item general metadata
+  generalMetadata: () => IO<GeneralMetadataItem[]>
+  // Tell if the query to retrieve dataverse item metadata is loading or not
+  isLoading: () => IO<boolean>
+}

--- a/src/domain/metadata/test/retrieveDataverseItemMetadata.spec.ts
+++ b/src/domain/metadata/test/retrieveDataverseItemMetadata.spec.ts
@@ -1,0 +1,214 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { StoreApi } from 'zustand'
+import * as TE from 'fp-ts/TaskEither'
+import * as MetadataDomain from '../domain'
+import type { AuditMetadataItem, GeneralMetadataItem } from '../query'
+import { type MetadataItem } from '../entity'
+import { type Deps } from '../command'
+// eslint-disable-next-line import/no-restricted-paths
+import { metadataSparqlGateway } from '../../../infra/metadata/sparql/sparqlGateway'
+
+const deps: Deps = {
+  metadataPort: metadataSparqlGateway,
+  language: 'en'
+}
+
+type GatewayResult = TE.TaskEither<Error, MetadataItem[]>
+
+type MetadataState = {
+  auditMetadata: AuditMetadataItem[]
+  generalMetadata: GeneralMetadataItem[]
+  isLoading: boolean
+}
+
+type Data1 = {
+  preloadedState?: MetadataDomain.Options
+  expectedState: MetadataState
+}
+
+type Data2 = {
+  preloadedState?: MetadataDomain.Options
+  dataverseItemId: string
+  mockGatewayResult: GatewayResult
+  expectedState: MetadataState
+  error?: Error
+}
+
+const defaultState: MetadataState = {
+  auditMetadata: [],
+  generalMetadata: [],
+  isLoading: false
+}
+
+const preloadedStateWithAuditMetadata1: MetadataDomain.Options = {
+  initialState: {
+    data: {
+      data: [{ category: 'auditMetadata', property: 'createdBy', value: 'Okp4' }],
+      isLoading: false
+    }
+  }
+}
+
+const stateWithAuditMetadata1: MetadataState = {
+  auditMetadata: [{ property: 'createdBy', value: 'Okp4' }],
+  generalMetadata: [],
+  isLoading: false
+}
+
+const preloadedStateWithGeneralMetadata1: MetadataDomain.Options = {
+  initialState: {
+    data: {
+      data: [{ category: 'generalMetadata', property: 'tags', value: ['tag1', 'tag2'] }],
+      isLoading: false
+    }
+  }
+}
+
+const stateWithGeneralMetadata1: MetadataState = {
+  auditMetadata: [],
+  generalMetadata: [{ property: 'tags', value: ['tag1', 'tag2'] }],
+  isLoading: false
+}
+
+const preloadedStateWithLoading1: MetadataDomain.Options = {
+  initialState: {
+    data: {
+      data: [],
+      isLoading: true
+    }
+  }
+}
+
+const stateWithLoading1: MetadataState = {
+  auditMetadata: [],
+  generalMetadata: [],
+  isLoading: true
+}
+
+const gatewayResult1 = TE.right([])
+
+const gatewayResult2 = TE.right([
+  {
+    category: 'generalMetadata',
+    property: 'title',
+    value: 'Toulouse Weather'
+  },
+  {
+    category: 'generalMetadata',
+    property: 'description',
+    value: 'Weather data about the Pink City'
+  },
+  {
+    category: 'auditMetadata',
+    property: 'createdBy',
+    value: 'Okp4'
+  }
+])
+
+const gatewayResult3 = TE.right([
+  {
+    category: 'generalMetadata',
+    property: 'topic',
+    value: 'blockchain'
+  },
+  {
+    category: 'generalMetadata',
+    property: 'format',
+    value: 'Shapefile'
+  },
+  {
+    category: 'auditMetadata',
+    property: 'lastModifiedBy',
+    value: 'Okp4'
+  }
+])
+
+const errorGatewayResult = TE.left(new Error())
+
+const stateWithGeneralAndAuditMetadata1: MetadataState = {
+  auditMetadata: [{ property: 'createdBy', value: 'Okp4' }],
+  generalMetadata: [
+    { property: 'title', value: 'Toulouse Weather' },
+    { property: 'description', value: 'Weather data about the Pink City' }
+  ],
+  isLoading: false
+}
+
+const stateWithGeneralAndAuditMetadata2: MetadataState = {
+  auditMetadata: [{ property: 'lastModifiedBy', value: 'Okp4' }],
+  generalMetadata: [
+    { property: 'topic', value: 'blockchain' },
+    { property: 'format', value: 'Shapefile' }
+  ],
+  isLoading: false
+}
+const initStore = (initialState?: MetadataDomain.Options): StoreApi<MetadataDomain.DomainAPI> =>
+  MetadataDomain.storeFactory(initialState)
+
+// eslint-disable-next-line max-lines-per-function
+describe(`Retrieve metadata from a dataverve item by its ID`, () => {
+  describe.each`
+    preloadedState                        | expectedState
+    ${undefined}                          | ${defaultState}
+    ${preloadedStateWithAuditMetadata1}   | ${stateWithAuditMetadata1}
+    ${preloadedStateWithGeneralMetadata1} | ${stateWithGeneralMetadata1}
+    ${preloadedStateWithLoading1}         | ${stateWithLoading1}
+  `('Given a preloaded state <$preloadedState>', ({ preloadedState, expectedState }: Data1) => {
+    describe(`when initializing state`, () => {
+      const store = initStore(preloadedState)
+
+      test(`then expect state to be ${JSON.stringify(expectedState)}`, () => {
+        const currentState: MetadataState = {
+          auditMetadata: store.getState().auditMetadata()(),
+          generalMetadata: store.getState().generalMetadata()(),
+          isLoading: store.getState().isLoading()()
+        }
+        expect(currentState).toStrictEqual(expectedState)
+      })
+    })
+  })
+
+  describe.each`
+    preloadedState                       | dataverseItemId | mockGatewayResult     | expectedState                        | error
+    ${undefined}                         | ${''}           | ${gatewayResult1}     | ${defaultState}                      | ${undefined}
+    ${undefined}                         | ${'id1'}        | ${gatewayResult2}     | ${stateWithGeneralAndAuditMetadata1} | ${undefined}
+    ${stateWithGeneralAndAuditMetadata1} | ${'id1'}        | ${gatewayResult3}     | ${stateWithGeneralAndAuditMetadata2} | ${undefined}
+    ${stateWithGeneralAndAuditMetadata1} | ${'id1'}        | ${gatewayResult3}     | ${stateWithGeneralAndAuditMetadata2} | ${undefined}
+    ${undefined}                         | ${'id1'}        | ${errorGatewayResult} | ${defaultState}                      | ${new Error()}
+  `(
+    'Given a preloaded state <$preloadedState> and a dataverse item id <$dataverseItemId> with this context dependency <$deps>',
+    ({ preloadedState, dataverseItemId, mockGatewayResult, expectedState, error }: Data2) => {
+      describe(`When calling retrieveDataverseItemMetadata command`, () => {
+        afterEach(() => {
+          jest.restoreAllMocks()
+        })
+
+        const store = initStore(preloadedState)
+
+        test(`then expect current state to be ${JSON.stringify(expectedState)}`, async () => {
+          const spiedMetadataGateway = jest.spyOn(metadataSparqlGateway, 'retrieveMetadata')
+          spiedMetadataGateway.mockReturnValue(mockGatewayResult)
+
+          const metadataRetrievalResult = await store
+            .getState()
+            .retrieveDataverseItemMetadata(dataverseItemId)(deps)()
+
+          const currentState: MetadataState = {
+            auditMetadata: store.getState().auditMetadata()(),
+            generalMetadata: store.getState().generalMetadata()(),
+            isLoading: store.getState().isLoading()()
+          }
+
+          if (error) {
+            expect(metadataRetrievalResult).toBeLeft()
+          } else {
+            expect(metadataRetrievalResult).toBeRight()
+          }
+
+          expect(spiedMetadataGateway).toHaveBeenCalled()
+          expect(currentState).toStrictEqual(expectedState)
+        })
+      })
+    }
+  )
+})

--- a/src/infra/metadata/sparql/dto.ts
+++ b/src/infra/metadata/sparql/dto.ts
@@ -1,0 +1,45 @@
+type DataType = {
+  dataType: string
+}
+type WithLanguage = {
+  'xml:lang': string
+}
+
+type SparqlBindingVars = {
+  vars: string[]
+}
+type SparqlBindingProperty = {
+  type: 'uri' | 'literal'
+  value: string
+}
+
+export type SparqlBindingValue =
+  | SparqlBindingProperty
+  | (SparqlBindingProperty & WithLanguage)
+  | (SparqlBindingProperty & DataType)
+
+type SparqlBinding = {
+  title: SparqlBindingProperty & WithLanguage
+  description: SparqlBindingProperty & WithLanguage
+  publisher: SparqlBindingProperty
+  tags: SparqlBindingProperty
+  temporalCoverage: SparqlBindingProperty
+  createdBy: SparqlBindingProperty
+  lastModifiedBy: SparqlBindingProperty
+  updatedOn: SparqlBindingProperty & DataType
+  createdOn: SparqlBindingProperty & DataType
+  category?: SparqlBindingProperty
+  creator?: SparqlBindingProperty
+  format?: SparqlBindingProperty
+  image?: SparqlBindingProperty
+  license?: SparqlBindingProperty
+  spatialCoverage?: SparqlBindingProperty
+  topic?: SparqlBindingProperty
+}
+
+export type SparqlResult = {
+  results: {
+    head: SparqlBindingVars
+    bindings: SparqlBinding[]
+  }
+}

--- a/src/infra/metadata/sparql/sparqlGateway.ts
+++ b/src/infra/metadata/sparql/sparqlGateway.ts
@@ -1,0 +1,228 @@
+import type { MetadataPort } from '@/domain/metadata/port'
+import { isError } from '@/util/util'
+import * as TE from 'fp-ts/TaskEither'
+import { pipe } from 'fp-ts/lib/function'
+import type { SparqlResult } from './dto'
+import type {
+  AuditMetadataProperty,
+  MetadataItem,
+  MetadataProperty
+} from '@/domain/metadata/entity'
+
+const auditMetadata = ['createdBy', 'createdOn', 'lastModifiedBy', 'updatedOn'] as const
+type AuditMetadata = (typeof auditMetadata)[number]
+const isAuditMetadata = (metadata: string): metadata is AuditMetadataProperty =>
+  auditMetadata.includes(metadata as AuditMetadata)
+
+export const metadataSparqlGateway: MetadataPort = {
+  // eslint-disable-next-line max-lines-per-function
+  retrieveMetadata: (
+    dataverseItemId: string,
+    language: string
+  ): TE.TaskEither<Error, MetadataItem[]> => {
+    const query = `
+    PREFIX core: <https://ontology.okp4.space/core/>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX dataset: <https://ontology.okp4.space/dataverse/dataset/>
+    PREFIX service: <https://ontology.okp4.space/dataverse/service/>
+    PREFIX zone: <https://ontology.okp4.space/dataverse/zone/>
+    
+    SELECT 
+       ?publisher ?createdBy ?updatedOn ?createdOn ?lastModifiedBy ?image ?creator ?startDate ?endDate ?tags
+        (SAMPLE(COALESCE(?titleUserLg, ?titleEnLg, ?titleFirstLg)) AS ?title) 
+        (SAMPLE(COALESCE(?descriptionUserLg, ?descriptionEnLg, ?descriptionFirstLg)) AS ?description) 
+        (SAMPLE(COALESCE(?licenseUserLg, ?licenseEnLg, ?licenseFirstLg)) AS ?license)
+        (SAMPLE(COALESCE(?spatialCoverageUserLg, ?spatialCoverageEnLg, ?spatialCoverageFirstLg)) AS ?spatialCoverage)
+        (SAMPLE(COALESCE(?topicUserLg, ?topicEnLg, ?topicFirstLg)) AS ?topic)
+        (SAMPLE(COALESCE(?formatUserLg, ?formatEnLg, ?formatFirstLg)) AS ?format)
+        (SAMPLE(COALESCE(?categoryUserLg, ?categoryEnLg, ?categoryFirstLg)) AS ?category)
+
+    WHERE {
+      {
+        ?generalMetadataID a <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+                         core:describes dataset:${dataverseItemId} .
+    
+        ?auditMetadataID a <https://ontology.okp4.space/metadata/AuditMetadata> ;
+                       core:describes dataset:${dataverseItemId} .
+      } UNION {
+        ?generalMetadataID a <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+                         core:describes service:${dataverseItemId} .
+    
+        ?auditMetadataID a <https://ontology.okp4.space/metadata/AuditMetadata> ;
+                       core:describes service:${dataverseItemId} .
+      } UNION {
+        ?generalMetadataID a <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+                         core:describes zone:${dataverseItemId} .
+    
+        ?auditMetadataID a <https://ontology.okp4.space/metadata/AuditMetadata> ;
+                       core:describes zone:${dataverseItemId} .
+      }            
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasTitle ?titleFirstLg .
+        OPTIONAL {
+          ?generalMetadataID core:hasTitle ?titleUserLg .
+          FILTER langMatches(lang(?titleUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?generalMetadataID core:hasTitle ?titleEnLg .
+          FILTER langMatches(lang(?titleEnLg), 'en')
+        }
+      }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasDescription ?descriptionFirstLg .
+        OPTIONAL {
+          ?generalMetadataID core:hasDescription ?descriptionUserLg .
+          FILTER langMatches(lang(?descriptionUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?generalMetadataID core:hasDescription ?descriptionEnLg .
+          FILTER langMatches(lang(?descriptionEnLg), 'en')
+        }
+      }
+  
+      {
+        SELECT ?generalMetadataID (GROUP_CONCAT(DISTINCT ?tag; separator=", ") AS ?tags)
+        WHERE {
+          OPTIONAL {
+            ?generalMetadataID core:hasTag ?tag .
+          }
+        }
+        GROUP BY ?generalMetadataID
+      }
+
+      OPTIONAL { ?generalMetadataID core:hasPublisher ?publisher . }
+      OPTIONAL { ?auditMetadataID core:createdBy ?createdBy . }
+      OPTIONAL { ?auditMetadataID core:updatedOn ?updatedOn . }
+      OPTIONAL { ?auditMetadataID core:createdOn ?createdOn . }
+      OPTIONAL { ?auditMetadataID core:lastModifiedBy ?lastModifiedBy . }
+      OPTIONAL { ?generalMetadataID core:hasImage ?image . }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasLicense ?licenseResource .
+        ?licenseResource skos:prefLabel ?licenseFirstLg .
+        OPTIONAL {
+          ?licenseResource skos:prefLabel ?licenseUserLg .
+          FILTER langMatches(lang(?licenseUserLg), '${language}') .
+        }
+        OPTIONAL {
+          ?licenseResource skos:prefLabel ?licenseEnLg .
+          FILTER langMatches(lang(?licenseEnLg),'en') .
+        }
+      }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasSpatialCoverage ?areaResource .
+        ?areaResource skos:prefLabel ?spatialCoverageFirstLg .
+        OPTIONAL {
+          ?areaResource skos:prefLabel ?spatialCoverageUserLg .
+          FILTER langMatches(lang(?spatialCoverageUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?areaResource skos:prefLabel ?spatialCoverageEnLg .
+          FILTER langMatches(lang(?spatialCoverageEnLg),'en') .
+        }
+      }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasTopic ?topicResource .
+        ?topicResource skos:prefLabel ?topicFirstLg . 
+        OPTIONAL {
+          ?topicResource skos:prefLabel ?topicUserLg . 
+          FILTER langMatches(lang(?topicUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?topicResource skos:prefLabel ?topicEnLg . 
+          FILTER langMatches(lang(?topicEnLg),'en') .
+        }
+      }
+      
+      OPTIONAL { ?generalMetadataID core:hasCreator ?creator . }
+
+    
+      OPTIONAL { 
+        ?generalMetadataID core:hasFormat ?formatResource .
+        ?formatResource skos:prefLabel ?formatFirstLg . 
+        OPTIONAL {
+          ?formatResource skos:prefLabel ?formatUserLg . 
+          FILTER langMatches(lang(?formatUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?formatResource skos:prefLabel ?formatEnLg . 
+          FILTER langMatches(lang(?formatEnLg),'en') .
+        }
+      }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasTemporalCoverage ?temporalCoverage .
+        OPTIONAL {  ?temporalCoverage core:hasStartDate ?startDate . }
+        OPTIONAL {  ?temporalCoverage core:hasEndDate ?endDate . }
+      }
+
+      OPTIONAL { 
+        ?generalMetadataID core:hasCategory ?categoryResource . 
+        OPTIONAL {
+          ?categoryResource skos:prefLabel ?categoryFirstLg .
+        }
+        OPTIONAL {
+          ?categoryResource skos:prefLabel ?categoryUserLg .
+          FILTER langMatches(lang(?categoryUserLg),'${language}') .
+        }
+        OPTIONAL {
+          ?categoryResource skos:prefLabel ?categoryEnLg .
+          FILTER langMatches(lang(?categoryEnLg),'en') .
+        }
+      }
+    }
+
+    GROUP BY ?publisher ?createdBy ?updatedOn ?createdOn ?lastModifiedBy ?image ?creator ?startDate ?endDate ?tags
+    `
+
+    const request: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        accept: 'application/sparql-results+json'
+      },
+      body: `query=${encodeURIComponent(query)}`
+    }
+
+    const fetchMetadata = (): TE.TaskEither<Error, Response> =>
+      TE.tryCatch(
+        async () => {
+          const resp = await fetch(APP_ENV.sparql['endpoint'], request)
+          if (!resp.ok) {
+            throw new Error(
+              `Oops.. A ${resp.status} HTTP error occurred with the following message: ${resp.statusText} `
+            )
+          }
+          return resp
+        },
+        error =>
+          isError(error)
+            ? error
+            : new Error(`Oops.. Something went wrong fetching ontology: ${JSON.stringify(error)}`)
+      )
+
+    const serializeResponse = (response: Response): TE.TaskEither<Error, SparqlResult> =>
+      TE.tryCatch(
+        async () => response.json(),
+        err =>
+          isError(err)
+            ? err
+            : new Error(
+                `Oops.. Something went wrong serializing sparql response: ${JSON.stringify(err)}`
+              )
+      )
+
+    const mapDtoToEntity = (dto: SparqlResult): MetadataItem[] =>
+      Object.entries(dto.results.bindings[0]).map(([key, value]) => ({
+        category: isAuditMetadata(key) ? 'auditMetadata' : 'generalMetadata',
+        property: key as MetadataProperty,
+        value: value.value
+      }))
+
+    return pipe(fetchMetadata(), TE.chain(serializeResponse), TE.map(mapDtoToEntity))
+  }
+}

--- a/src/ui/store/index.ts
+++ b/src/ui/store/index.ts
@@ -3,6 +3,7 @@ import * as Wallet from '@/domain/wallet/domain'
 import * as Dataverse from '@/domain/dataverse/domain'
 import * as File from '@/domain/file/domain'
 import * as Vocabulary from '@/domain/vocabulary/domain'
+import * as Metadata from '@/domain/metadata/domain'
 import * as App from './appStore'
 
 import type { StoreApi } from 'zustand'
@@ -27,6 +28,9 @@ export const useDataverseStore = createStoreHook(dataverseStore)
 
 const fileStore = File.storeFactory()
 export const useFileStore = createStoreHook(fileStore)
+
+const metadataStore = Metadata.storeFactory()
+export const useMetadataStore = createStoreHook(metadataStore)
 
 const appStore = App.storeFactory()
 export const useAppStore = createStoreHook(appStore)


### PR DESCRIPTION
This PR aims to implement metadata domain described in both of these issues: [Audit](https://app.zenhub.com/workspaces/dev-board--63e210cc9b1f2f73ee3f4e5f/issues/gh/okp4/dataverse-portal/204) & [General](https://app.zenhub.com/workspaces/dev-board--63e210cc9b1f2f73ee3f4e5f/issues/gh/okp4/dataverse-portal/203).

It implements the connexion to the ontology to get a dataset / service / zone metadata.

This PR concerns the domain part, the UI update will be made in another dedicated PR.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added a new feature to retrieve and manage metadata for Dataverse items. This includes the ability to fetch metadata in different languages and handle potential errors during the retrieval process.
- Introduced a Zustand store for managing metadata state, including loading status and data manipulation.
- Implemented type guards for differentiating between audit and general metadata items.

**Refactor:**
- Introduced new types and interfaces to better represent metadata properties, categories, and items, improving code readability and maintainability.

**Test:**
- Added comprehensive test cases for the metadata retrieval functionality, ensuring robust and reliable operation.

**Chore:**
- Integrated the new metadata management feature into the existing store structure, ensuring seamless interaction with other parts of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->