### PR TITLE
Fix/popover component

### DIFF
--- a/src/ui/component/popover/popover.tsx
+++ b/src/ui/component/popover/popover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import classNames from 'classnames'
 import * as RPopover from '@radix-ui/react-popover'
@@ -33,11 +33,13 @@ export const Popover: FC<PopoverProps> = ({
   side = 'bottom',
   sideOffset = 8
 }) => {
-  const containerRef = useRef<HTMLElement | null>(null)
+  const [containerElement, setContainerElement] = useState<HTMLElement | null>(container ?? null)
 
   useEffect(() => {
-    containerRef.current = container ?? document.getElementById('popover-root')
-  }, [container])
+    if (containerElement) return
+
+    setContainerElement(document.getElementById('popover-root'))
+  }, [containerElement])
 
   return (
     <RPopover.Root onOpenChange={onOpenChange} open={open}>
@@ -55,7 +57,7 @@ export const Popover: FC<PopoverProps> = ({
           </div>
         )}
       </RPopover.Trigger>
-      <RPopover.Portal container={containerRef.current}>
+      <RPopover.Portal container={containerElement}>
         <RPopover.Content
           align={align}
           className={classNames('okp4-dataverse-portal-popover-content', contentClassName)}


### PR DESCRIPTION
## Issue
The problem lies in using [refs](https://react.dev/learn/referencing-values-with-refs), which don't trigger re-renders in React. 

When `popover-root` DOM element is retrieved in `useEffect`, the component doesn't re-render, and as a result, the popover content isn't displayed.

This bug is currently masked when the Popover's parent component triggers a re-render.

## Fix
Use a `useState` hook that triggers a component re-render as soon as the `popover-root` DOM element is found.