### PR TITLE
Feat/share service route and page

### DIFF
--- a/src/ui/page/share/i18n/share_de.json
+++ b/src/ui/page/share/i18n/share_de.json
@@ -18,7 +18,6 @@
       "title": "Ich teile einen Dienst",
       "description": "Einfache Freigabe Ihres Dienstes im Dataverse"
     },
-    "soonAvailable": "Bald verfügbar",
     "metadataFilling": {
       "stepTitle": "Füllen Sie die Metadaten aus",
       "stepDescription": "Bitte füllen Sie die Metadaten des Datensatzes zu Referenzzwecken aus. Es wird dringend davon abgeraten, personenbezogene Daten in die Metadaten aufzunehmen, da sie unveränderlich sind, sobald sie in der Blockchain gespeichert sind, was nicht den GDPR-Vorschriften entspricht.",

--- a/src/ui/page/share/i18n/share_en.json
+++ b/src/ui/page/share/i18n/share_en.json
@@ -18,7 +18,6 @@
       "title": "I share a service",
       "description": "Easily share your service in the dataverse"
     },
-    "soonAvailable": "Soon available",
     "metadataFilling": {
       "stepTitle": "Fill in the metadata",
       "stepDescription": "Please complete the dataset metadata for reference purposes. It is highly discouraged to include personal data in the metadata due to its immutability once stored in the blockchain, which does not comply with GDPR regulations.",

--- a/src/ui/page/share/i18n/share_fr.json
+++ b/src/ui/page/share/i18n/share_fr.json
@@ -18,7 +18,6 @@
       "title": "Je partage un service",
       "description": "Partagez facilement votre service dans le dataverse"
     },
-    "soonAvailable": "Bientôt disponible",
     "metadataFilling": {
       "stepTitle": "Renseigner les métadonnées",
       "stepDescription": "Saisir les métadonnées de l'ensemble de données à référencer. Il est fortement déconseillé d'utiliser des données personnelles dans les métadonnées, car elles sont immuables une fois dans la blockchain et ne sont pas conformes au RGPD.",

--- a/src/ui/page/share/service/shareService.scss
+++ b/src/ui/page/share/service/shareService.scss
@@ -1,0 +1,16 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+@import '@/ui/style/mixins';
+
+.okp4-dataverse-portal-share-service-page-main {
+  @include with-theme {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .okp4-dataverse-portal-share-service-page-main-title {
+      @include norse-gradient-header($line-height: 36px);
+      margin-bottom: 20px;
+    }
+  }
+}

--- a/src/ui/page/share/service/shareService.tsx
+++ b/src/ui/page/share/service/shareService.tsx
@@ -1,0 +1,26 @@
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ServiceReferenceSelection } from './steps/serviceReferenceSelection/serviceReferenceSelection'
+import { Stepper } from '@/ui/component/stepper/stepper'
+import './shareService.scss'
+import '../i18n/index'
+
+export const ShareService: FC = () => {
+  const { t } = useTranslation('share')
+
+  const referenceServiceSelection = {
+    id: 'step1',
+    content: <ServiceReferenceSelection />
+  }
+
+  const steps = [referenceServiceSelection]
+
+  return (
+    <div className="okp4-dataverse-portal-share-service-page-main">
+      <h1 className="okp4-dataverse-portal-share-service-page-main-title">
+        {t('share.service.title')}
+      </h1>
+      <Stepper steps={steps} />
+    </div>
+  )
+}

--- a/src/ui/page/share/service/steps/serviceReferenceSelection/serviceReferenceSelection.scss
+++ b/src/ui/page/share/service/steps/serviceReferenceSelection/serviceReferenceSelection.scss
@@ -1,0 +1,20 @@
+@import '@/ui/style/fonts.scss';
+@import '@/ui/style/theme.scss';
+
+.okp4-dataverse-portal-share-service-page-service-reference-container {
+  @include with-theme() {
+    display: flex;
+    flex-direction: column;
+    margin-top: 26px;
+    height: 100%;
+
+    .okp4-dataverse-portal-share-service-page-service-reference-title {
+      @include noto-sans(700);
+      margin-bottom: 22px;
+      font-size: 28px;
+      line-height: 28px;
+      letter-spacing: 0.4px;
+      color: themed('text');
+    }
+  }
+}

--- a/src/ui/page/share/service/steps/serviceReferenceSelection/serviceReferenceSelection.tsx
+++ b/src/ui/page/share/service/steps/serviceReferenceSelection/serviceReferenceSelection.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+import './serviceReferenceSelection.scss'
+
+export const ServiceReferenceSelection: FC = () => (
+  <div className="okp4-dataverse-portal-share-service-page-service-reference-container">
+    <h2 className="okp4-dataverse-portal-share-service-page-service-reference-title">
+      Content title
+    </h2>
+  </div>
+)

--- a/src/ui/page/share/share.scss
+++ b/src/ui/page/share/share.scss
@@ -44,27 +44,10 @@
 
         &.right {
           @include bi-column-item('right');
+          cursor: pointer;
 
           .okp4-dataverse-portal-share-page-ilustration {
             background: center / contain url('@/ui/asset/images/share-service.webp') no-repeat;
-          }
-
-          &:hover {
-            @include transition-bg-color;
-            background-color: themed('darkblue-emphasis-900');
-
-            .okp4-dataverse-portal-share-page-text-container {
-              h3,
-              p {
-                color: themed('white-emphasis');
-                opacity: 0.4;
-              }
-
-              .okp4-dataverse-portal-share-page-text-disabled {
-                visibility: visible;
-                opacity: 1;
-              }
-            }
           }
         }
 
@@ -94,18 +77,6 @@
             align-self: center;
             color: themed('text');
             margin-top: 19px;
-          }
-
-          .okp4-dataverse-portal-share-page-text-disabled {
-            position: relative;
-            bottom: -5%;
-            visibility: hidden;
-            display: flex;
-            align-self: center;
-
-            @include use-breakpoints('large-desktop') {
-              bottom: -15%;
-            }
           }
         }
 

--- a/src/ui/page/share/share.tsx
+++ b/src/ui/page/share/share.tsx
@@ -15,6 +15,10 @@ export const Share: FC = () => {
     navigate(routes.shareDataset)
   }, [navigate])
 
+  const handleShareService = useCallback(() => {
+    navigate(routes.shareService)
+  }, [navigate])
+
   return (
     <div className="okp4-dataverse-portal-share-page-main">
       <div className="okp4-dataverse-portal-share-page-content">
@@ -30,15 +34,15 @@ export const Share: FC = () => {
             </div>
           </>
         </Card>
-        <Card mainClassName="okp4-dataverse-portal-share-page-card right">
+        <Card
+          mainClassName="okp4-dataverse-portal-share-page-card right"
+          onClick={handleShareService}
+        >
           <>
             <div className="okp4-dataverse-portal-share-page-ilustration" />
             <div className="okp4-dataverse-portal-share-page-text-container">
               <h3>{t('share.service.title')}</h3>
               <p>{t('share.service.description')}</p>
-              <h3 className="okp4-dataverse-portal-share-page-text-disabled">
-                {t('share.soonAvailable')}
-              </h3>
             </div>
           </>
         </Card>

--- a/src/ui/routes.tsx
+++ b/src/ui/routes.tsx
@@ -7,6 +7,7 @@ import { Governance } from '@/ui/page/dataverse/zone/governance/governance'
 import { NotFoundError } from '@/ui/page/error/notFoundError/notFoundError'
 import { Share } from '@/ui/page/share/share'
 import { ShareDataset } from '@/ui/page/share/dataset/shareDataset'
+import { ShareService } from '@/ui/page/share/service/shareService'
 import { UnsupportedFeatureLayout } from '@/ui//view/unsupportedFeatureLayout/unsupportedFeatureLayout'
 
 export enum routes {
@@ -18,6 +19,7 @@ export enum routes {
   governance = 'dataverse/zone/:id/governance/:sectionId?/:subsectionId?',
   share = 'share',
   shareDataset = '/share/data',
+  shareService = '/share/service',
   notFoundError = '*'
 }
 
@@ -74,6 +76,12 @@ export const appRoutes: Route[] = [
     id: 'shareDataset',
     path: routes.shareDataset,
     element: <ShareDataset />,
+    layout: <UnsupportedFeatureLayout />
+  },
+  {
+    id: 'shareService',
+    path: routes.shareService,
+    element: <ShareService />,
     layout: <UnsupportedFeatureLayout />
   }
 ]


### PR DESCRIPTION
This PR introduces route and initialisation wrapper for service sharing, enabling access to share service page. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new `ShareService` page that includes a step-by-step process for service reference selection. This feature enhances the user interface by providing a more structured and intuitive way to share services.
- Updated the `Share` page with improved interactivity. The hover effect on the `.right` class has been removed, and a click event has been added to navigate to the `ShareService` page.
- Implemented internationalization for the title of the `ShareService` page, improving accessibility for users in different locales.

**Refactor:**
- Introduced a new route `/share/service` for the `ShareService` page, improving the organization and readability of the application's routing structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->