### PR TITLE
Refactor/fonts and mixins imports

### DIFF
--- a/src/ui/page/dataverse/dataverse.scss
+++ b/src/ui/page/dataverse/dataverse.scss
@@ -1,4 +1,3 @@
-@import '@/ui/style/fonts.scss';
 @import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins.scss';
 

--- a/src/ui/page/home/home.scss
+++ b/src/ui/page/home/home.scss
@@ -1,4 +1,3 @@
-@import '@/ui/style/fonts.scss';
 @import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins.scss';
 

--- a/src/ui/page/share/dataset/shareDataset.scss
+++ b/src/ui/page/share/dataset/shareDataset.scss
@@ -1,4 +1,3 @@
-@import '@/ui/style/fonts.scss';
 @import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins';
 

--- a/src/ui/page/share/service/shareService.scss
+++ b/src/ui/page/share/service/shareService.scss
@@ -1,4 +1,3 @@
-@import '@/ui/style/fonts.scss';
 @import '@/ui/style/theme.scss';
 @import '@/ui/style/mixins';
 

--- a/src/ui/style/mixins.scss
+++ b/src/ui/style/mixins.scss
@@ -1,4 +1,5 @@
 @import '@/ui/style/theme.scss';
+@import '@/ui/style/fonts.scss';
 
 @mixin use-breakpoints($breakpoints) {
   @each $breakpoint in $breakpoints {


### PR DESCRIPTION
This PR consist of importing `fonts.scss` file in `mixins.scss` in order to avoid it's import in each stylesheets that uses `font-family` or `font-weight` properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Consolidated font imports across multiple SCSS files into a single `fonts.scss` file for better maintainability and consistency. This change impacts the `dataverse.scss`, `home.scss`, `shareDataset.scss`, `shareService.scss`, and `mixins.scss` files. End users should not notice any changes as this is a code-level optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->